### PR TITLE
Fix stdout/stderr handling to prevent JSON-RPC communication errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,10 +164,11 @@ class GodotServer {
 
   /**
    * Log debug messages if debug mode is enabled
+   * Using stderr instead of stdout to avoid interfering with JSON-RPC communication
    */
   private logDebug(message: string): void {
     if (DEBUG_MODE) {
-      console.debug(`[DEBUG] ${message}`);
+      console.error(`[DEBUG] ${message}`);
     }
   }
 
@@ -332,8 +333,8 @@ class GodotServer {
 
     // If we get here, we couldn't find Godot
     this.logDebug(`Warning: Could not find Godot in common locations for ${osPlatform}`);
-    console.warn(`[SERVER] Could not find Godot in common locations for ${osPlatform}`);
-    console.warn(`[SERVER] Set GODOT_PATH=/path/to/godot environment variable or pass { godotPath: '/path/to/godot' } in the config to specify the correct path.`);
+    console.error(`[SERVER] Could not find Godot in common locations for ${osPlatform}`);
+    console.error(`[SERVER] Set GODOT_PATH=/path/to/godot environment variable or pass { godotPath: '/path/to/godot' } in the config to specify the correct path.`);
 
     if (this.strictPathValidation) {
       // In strict mode, throw an error
@@ -349,8 +350,8 @@ class GodotServer {
       }
 
       this.logDebug(`Using default path: ${this.godotPath}, but this may not work.`);
-      console.warn(`[SERVER] Using default path: ${this.godotPath}, but this may not work.`);
-      console.warn(`[SERVER] This fallback behavior will be removed in a future version. Set strictPathValidation: true to opt-in to the new behavior.`);
+      console.error(`[SERVER] Using default path: ${this.godotPath}, but this may not work.`);
+      console.error(`[SERVER] This fallback behavior will be removed in a future version. Set strictPathValidation: true to opt-in to the new behavior.`);
     }
   }
 
@@ -2171,13 +2172,13 @@ class GodotServer {
           process.exit(1);
         } else {
           // In compatibility mode, warn but continue with the default path
-          console.warn(`[SERVER] Warning: Using potentially invalid Godot path: ${this.godotPath}`);
-          console.warn('[SERVER] This may cause issues when executing Godot commands');
-          console.warn('[SERVER] This fallback behavior will be removed in a future version. Set strictPathValidation: true to opt-in to the new behavior.');
+          console.error(`[SERVER] Warning: Using potentially invalid Godot path: ${this.godotPath}`);
+          console.error('[SERVER] This may cause issues when executing Godot commands');
+          console.error('[SERVER] This fallback behavior will be removed in a future version. Set strictPathValidation: true to opt-in to the new behavior.');
         }
       }
 
-      console.log(`[SERVER] Using Godot at: ${this.godotPath}`);
+      console.error(`[SERVER] Using Godot at: ${this.godotPath}`);
 
       const transport = new StdioServerTransport();
       await this.server.connect(transport);


### PR DESCRIPTION
## Fix stdout/stderr handling to prevent JSON-RPC communication errors
This PR addresses an issue where debug messages were being output to stdout, which interfered with the JSON-RPC protocol. The MCP protocol requires that stdout be used exclusively for JSON-RPC messages.

### Changes
- Modified the `logDebug()` function to use `console.error()` instead of `console.debug()`
- Replaced all instances of `console.warn()` with `console.error()`
- Replaced `console.log()` with `console.error()` for server status messages

These changes ensure that stdout is used exclusively for JSON-RPC communication, while all logging and debugging information goes to stderr, making godot-mcp more compatible with MCP clients that strictly follow the protocol specification.

### Testing
Tested with Claude's MCP client, which previously failed with JSON parsing errors. After these changes, the communication works correctly.

### Issues
https://github.com/Coding-Solo/godot-mcp/issues/24
