### PR TITLE
Add Steam Godot Path for MacOS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -301,7 +301,8 @@ class GodotServer {
         '/Applications/Godot.app/Contents/MacOS/Godot',
         '/Applications/Godot_4.app/Contents/MacOS/Godot',
         `${process.env.HOME}/Applications/Godot.app/Contents/MacOS/Godot`,
-        `${process.env.HOME}/Applications/Godot_4.app/Contents/MacOS/Godot`
+        `${process.env.HOME}/Applications/Godot_4.app/Contents/MacOS/Godot`,
+        `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Godot Engine/Godot.app/Contents/MacOS/Godot`
       );
     } else if (osPlatform === 'win32') {
       possiblePaths.push(


### PR DESCRIPTION
One way to install Godot is via Steam, and this way was not covered. Here's a simple one-line fix.