### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-
 # Godot MCP
 
 [![](https://badge.mcpx.dev?type=server 'MCP Server')](https://modelcontextprotocol.io/introduction)
 [![Made with Godot](https://img.shields.io/badge/Made%20with-Godot-478CBF?style=flat&logo=godot%20engine&logoColor=white)](https://godotengine.org)
 [![](https://img.shields.io/badge/Node.js-339933?style=flat&logo=nodedotjs&logoColor=white 'Node.js')](https://nodejs.org/en/download/)
 [![](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white 'TypeScript')](https://www.typescriptlang.org/)
+
+<a href="https://glama.ai/mcp/servers/@Coding-Solo/godot-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Coding-Solo/godot-mcp/badge" alt="Godot MCP server" />
+</a>
 
 [![](https://img.shields.io/github/last-commit/Coding-Solo/godot-mcp 'Last Commit')](https://github.com/Coding-Solo/godot-mcp/commits/main)
 [![](https://img.shields.io/github/stars/Coding-Solo/godot-mcp 'Stars')](https://github.com/Coding-Solo/godot-mcp/stargazers)


### PR DESCRIPTION
This PR adds a badge for the [Godot MCP](https://glama.ai/mcp/servers/@Coding-Solo/godot-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Coding-Solo/godot-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Coding-Solo/godot-mcp/badge" alt="Godot MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.