### PR TITLE
Passing custom Godot CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,22 @@ Once configured, your AI assistant will automatically run the MCP server when ne
 "Update UID references in my Godot project after upgrading to 4.4"
 ```
 
+### Passing custom Godot CLI arguments
+
+`run_project` now accepts an optional `extraArgs` array. These strings are appended directly to the Godot command line so you can trigger headless runs, select custom main scenes, or pass feature flags without leaving your IDE. Example request payload:
+
+```jsonc
+{
+  "name": "run_project",
+  "arguments": {
+    "projectPath": "/absolute/path/to/project",
+    "extraArgs": ["--headless", "--test=sample_spawn_test"]
+  }
+}
+```
+
+> ℹ️  For safety, the server automatically injects `--path` for you and filters out duplicate `--path`/`-p` flags. Use `extraArgs` strictly for additional Godot options (e.g., `--headless`, `--quit`, `--test=...`).
+
 ## Implementation Details
 
 ### Architecture


### PR DESCRIPTION
This pull request adds support for passing custom Godot CLI arguments when running a project through the MCP server, making it easier to trigger headless runs, specify main scenes, or use feature flags directly from your IDE. The changes include updates to the API schema, the server logic, and documentation to describe the new capability and its safety checks.

**New feature: Custom Godot CLI arguments**

* Updated the API schema for the `run_project` command to accept an optional `extraArgs` array, allowing users to specify additional CLI arguments for the Godot executable.
* Added logic in the server to parse, sanitize, and append custom CLI arguments from `extraArgs`, while filtering out disallowed flags like `--path` and `-p` to prevent conflicts. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1104-R1109) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1168-R1203)

**Documentation improvements**

* Updated `README.md` to describe how to use the new `extraArgs` option, including example payloads and safety notes about argument filtering.