### PR TITLE
fix: Change log message from console.log to console.error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2185,7 +2185,7 @@ class GodotServer {
         }
       }
 
-      console.log(`[SERVER] Using Godot at: ${this.godotPath}`);
+      console.error(`[SERVER] Using Godot at: ${this.godotPath}`);
 
       const transport = new StdioServerTransport();
       await this.server.connect(transport);


### PR DESCRIPTION
This output prevents codex-cli from accepting handshake. Proposed simplest change.