### PR TITLE
fix: avoid stdout log during MCP init

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ Create a file at `.cursor/mcp.json` in your project directory with the following
 }
 ```
 
+#### Option C: Configure with Codex CLI
+
+Add a server entry to your Codex config (typically `~/.codex/config.toml`):
+
+```toml
+[mcp_servers.godot]
+command = "node"
+args = ["/absolute/path/to/godot-mcp/build/index.js"]
+env = { DEBUG = "true" }
+```
+
 ### Step 3: Optional Environment Variables
 
 You can customize the server behavior with these environment variables:

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ class GodotServer {
 
     // Set the path to the operations script
     this.operationsScriptPath = join(__dirname, 'scripts', 'godot_operations.gd');
-    if (debugMode) console.debug(`[DEBUG] Operations script path: ${this.operationsScriptPath}`);
+    if (debugMode) console.error(`[DEBUG] Operations script path: ${this.operationsScriptPath}`);
 
     // Initialize the MCP server
     this.server = new Server(
@@ -167,7 +167,7 @@ class GodotServer {
    */
   private logDebug(message: string): void {
     if (DEBUG_MODE) {
-      console.debug(`[DEBUG] ${message}`);
+      console.error(`[DEBUG] ${message}`);
     }
   }
 


### PR DESCRIPTION
Move startup log to stderr to prevent stdout noise from breaking MCP initialization.