### PR TITLE
remove invalid 'default' keyword from tool schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -775,7 +775,6 @@ class GodotServer {
               rootNodeType: {
                 type: 'string',
                 description: 'Type of the root node (e.g., Node2D, Node3D)',
-                default: 'Node2D',
               },
             },
             required: ['projectPath', 'scenePath'],
@@ -798,7 +797,6 @@ class GodotServer {
               parentNodePath: {
                 type: 'string',
                 description: 'Path to the parent node (e.g., "root" or "root/Player")',
-                default: 'root',
               },
               nodeType: {
                 type: 'string',


### PR DESCRIPTION
The `default` keyword is not supported by all MCP clients (VS Code Copilot, GPT-5, etc.) and causes tool validation failures.

Fixes #40 
Fixes #55 (tested inside of copilot chat)

