### PR TITLE
feat: add E2E testing bridge with 25 new MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+godot-mcp is an MCP (Model Context Protocol) server that lets AI assistants interact with the Godot game engine. It provides tools for launching the editor, running projects, managing scenes/nodes, and capturing debug output. Written in TypeScript, compiled to a Node.js executable.
+
+## Build & Development Commands
+
+```bash
+npm install           # Install dependencies
+npm run build         # TypeScript compile + post-build (chmod, copy GDScript)
+npm run watch         # Watch mode with auto-rebuild
+npm run inspector     # Launch MCP Inspector for interactive testing
+```
+
+There is no automated test suite. Use `npm run inspector` for manual testing. Set `DEBUG=true` for verbose server logging.
+
+## Architecture
+
+### Core server + E2E bridge modules
+
+The MCP server core lives in `src/index.ts` as the `GodotServer` class. Complex Godot operations delegate to `src/scripts/godot_operations.gd`, a headless GDScript executed via Godot's CLI. E2E testing tools are in separate modules.
+
+**Three execution paths:**
+- **Direct CLI**: Simple operations (launch editor, get version, run project) spawn Godot directly
+- **Bundled GDScript**: Complex operations (create scene, add node, load sprite, export mesh library) pass a JSON params blob to `godot_operations.gd` via `execFile()`
+- **WebSocket bridge**: E2E testing tools connect to a running Godot game via `src/bridge.ts` ↔ `src/scripts/test_bridge.gd` over JSON-RPC/WebSocket
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `src/index.ts` | GodotServer class, core 15 tools, wires in E2E tools |
+| `src/bridge.ts` | BridgeClient — WebSocket client + JSON-RPC transport |
+| `src/e2e-tools.ts` | 25 E2E tool schemas + handlers, ServerContext interface |
+| `src/scripts/godot_operations.gd` | Headless GDScript for scene/node operations |
+| `src/scripts/test_bridge.gd` | TestBridge autoload — WebSocket server inside running Godot game |
+
+### Key class: GodotServer
+
+```
+GodotServer
+  ├── detectGodotPath()        # Platform-aware auto-detection (macOS/Windows/Linux)
+  ├── executeOperation()       # Runs godot_operations.gd with operation name + JSON params
+  ├── setupToolHandlers()      # Registers all 40 MCP tools (15 core + 25 E2E)
+  ├── normalizeParameters()    # Accepts both snake_case and camelCase input
+  ├── handle*(args)            # One handler method per core MCP tool
+  └── bridge: BridgeClient     # WebSocket client for E2E tools
+```
+
+### E2E Testing Bridge
+
+`BridgeClient` (src/bridge.ts) manages WebSocket connection to `TestBridge.gd` running inside a Godot game. The bridge uses JSON-RPC with UUID-based request tracking and per-request timeouts.
+
+**TestBridge.gd** is a Godot autoload activated by `--test-bridge` CLI flag. It runs a `TCPServer` + `WebSocketPeer` server, processes requests in `_process()` (non-blocking), and supports async handlers via `_pending_responses`.
+
+**Safety**: `--unsafe` flag required for `evaluate_expression`, `wait_for_condition`, and dangerous methods in `call_method`. Singleton names reject path traversal. `find_nodes` capped at 1000 results.
+
+### Parameter normalization pipeline
+
+Tool input (either convention) → normalize to camelCase → process → convert to snake_case → pass to GDScript. The `parameterMappings` dict drives this bidirectional conversion.
+
+### Process management
+
+Only one active Godot process at a time. `activeProcess` tracks the spawned process and captures stdout/stderr for retrieval via `get_debug_output`.
+
+### Build post-processing
+
+`scripts/build.js` runs after `tsc`: makes `build/index.js` executable and copies GDScript files (`godot_operations.gd`, `test_bridge.gd`) into `build/scripts/`.
+
+## MCP Tools (40 total)
+
+### Core Tools (15)
+
+| Category | Tools |
+|---|---|
+| Discovery | `list_projects`, `get_project_info`, `get_godot_version` |
+| Execution | `launch_editor`, `run_project`, `get_debug_output`, `stop_project` |
+| Scene ops | `create_scene`, `add_node`, `save_scene`, `load_sprite` |
+| Advanced | `export_mesh_library`, `get_uid`, `update_project_uids` |
+
+### E2E Testing Tools (25)
+
+| Category | Tools |
+|---|---|
+| Connection | `connect_to_game`, `disconnect_from_game`, `get_bridge_status` |
+| Orchestration | `install_test_bridge`, `run_project_with_bridge` |
+| Scene tree | `get_tree`, `find_nodes`, `get_node_properties`, `set_node_property`, `call_method` |
+| Game state | `get_singleton`, `evaluate_expression` (unsafe), `get_performance_metrics` |
+| Input | `send_key`, `send_mouse_click`, `send_mouse_drag`, `send_text` |
+| Waiting | `wait_for_signal`, `wait_for_condition` (unsafe), `wait_for_node`, `wait_for_property` |
+| Visual | `take_screenshot`, `get_viewport_info` |
+| Scene control | `reset_scene`, `load_scene` |
+
+## Adding New Tools
+
+### Core tools (in src/index.ts)
+1. Define tool schema in `setupToolHandlers()` with name, description, and `inputSchema`
+2. Add a `handle*` method following the existing pattern (validate → execute → return content/error)
+3. Wire the handler in the `CallToolRequestSchema` switch
+4. Use `createErrorResponse()` for errors (includes suggested solutions)
+5. Update README.md
+
+### E2E tools (in src/e2e-tools.ts)
+1. Add tool schema to `getE2EToolSchemas()`
+2. Add handler case in `handleE2ETool()`
+3. For simple bridge pass-through: use `handleBridgePassthrough()` with capability checking
+4. For wait tools: use `handleWaitTool()` with extended timeout
+5. Add GDScript handler in `src/scripts/test_bridge.gd` (`_handle_<method_name>`)
+6. Add parameter mappings to `getE2EParameterMappings()` if needed
+
+## Security Patterns
+
+- All subprocess execution uses `execFile()` with argument arrays (no shell interpolation)
+- Long-lived game processes use `spawn()` (for `run_project_with_bridge`)
+- Path validation rejects `..` traversal sequences
+- Godot path is validated via actual execution before use, with results cached in `validatedPaths`
+- E2E bridge: `--unsafe` flag gates `evaluate_expression`, `wait_for_condition`, and dangerous methods in `call_method`
+- Singleton name validation rejects `..` and `/` to prevent traversal
+- `find_nodes` results capped at 1000 to prevent memory exhaustion
+
+## Environment Variables
+
+- `GODOT_PATH` - Override auto-detected Godot executable location
+- `DEBUG=true` - Enable verbose stderr logging
+
+## Key Conventions
+
+- Logging goes to `console.error()` (stderr) to avoid interfering with JSON-RPC on stdout
+- ES modules (`"type": "module"` in package.json)
+- TypeScript strict mode, target ES2022
+- Conventional commits: `feat`, `fix`, `chore`, `refactor`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,29 @@
 {
   "name": "godot-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.7.9",
-        "fs-extra": "^11.2.0"
+        "fs-extra": "^11.2.0",
+        "ws": "^8.18.0"
       },
       "bin": {
         "godot-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.11.24",
+        "@types/ws": "^8.5.0",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -40,6 +45,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/asynckit": {
@@ -496,6 +511,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.7.9",
-    "fs-extra": "^11.2.0"
+    "fs-extra": "^11.2.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",
+    "@types/ws": "^8.5.0",
     "typescript": "^5.3.3"
   },
   "engines": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,8 +19,14 @@ try {
     path.join(__dirname, '..', 'src', 'scripts', 'godot_operations.gd'),
     path.join(__dirname, '..', 'build', 'scripts', 'godot_operations.gd')
   );
-  
-  console.log('Successfully copied godot_operations.gd to build/scripts');
+
+  // Copy the test_bridge.gd file
+  fs.copyFileSync(
+    path.join(__dirname, '..', 'src', 'scripts', 'test_bridge.gd'),
+    path.join(__dirname, '..', 'build', 'scripts', 'test_bridge.gd')
+  );
+
+  console.log('Successfully copied GDScript files to build/scripts');
 } catch (error) {
   console.error('Error copying scripts:', error);
   process.exit(1);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,0 +1,226 @@
+/**
+ * BridgeClient — WebSocket client + JSON-RPC transport for E2E TestBridge communication.
+ *
+ * Connects to TestBridge.gd running inside a Godot game instance via WebSocket,
+ * exchanges JSON-RPC messages, and manages connection lifecycle.
+ */
+
+import WebSocket from 'ws';
+import { randomUUID } from 'crypto';
+
+/**
+ * Capabilities reported by TestBridge during the hello handshake.
+ */
+export interface BridgeCapabilities {
+  protocol_version: string;
+  capabilities: string[];
+  unsafe_mode: boolean;
+  godot_version: string;
+  project_name: string;
+  display_mode: string;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * WebSocket client that speaks JSON-RPC to TestBridge.gd.
+ */
+export class BridgeClient {
+  private ws: WebSocket | null = null;
+  private pendingRequests: Map<string, PendingRequest> = new Map();
+  private capabilities: BridgeCapabilities | null = null;
+
+  /**
+   * Connect to a running TestBridge WebSocket server.
+   * Performs the hello handshake and caches capabilities.
+   */
+  async connect(host: string = 'localhost', port: number = 9505, timeoutMs: number = 5000): Promise<BridgeCapabilities> {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.disconnect();
+    }
+
+    return new Promise<BridgeCapabilities>((resolve, reject) => {
+      const url = `ws://${host}:${port}`;
+      let settled = false;
+
+      const settle = (err?: Error, caps?: BridgeCapabilities) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(connectionTimeout);
+        if (err) reject(err);
+        else resolve(caps!);
+      };
+
+      const connectionTimeout = setTimeout(() => {
+        if (this.ws) {
+          this.ws.removeAllListeners();
+          this.ws.terminate();
+          this.ws = null;
+        }
+        settle(new Error(`Connection timeout after ${timeoutMs}ms — could not reach TestBridge at ${url}`));
+      }, timeoutMs);
+
+      this.ws = new WebSocket(url);
+
+      this.ws.on('open', async () => {
+        try {
+          const caps = await this.send('hello', undefined, timeoutMs) as BridgeCapabilities;
+          this.capabilities = caps;
+          this.setupHandlers();
+          settle(undefined, caps);
+        } catch (err) {
+          this.disconnect();
+          settle(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+
+      this.ws.on('error', (err) => {
+        this.ws = null;
+        settle(new Error(`WebSocket connection error: ${err.message}`));
+      });
+
+      this.ws.on('close', () => {
+        this.ws = null;
+        settle(new Error(`WebSocket connection closed before completing handshake`));
+      });
+
+      // Set up the message handler for the handshake phase
+      this.ws.on('message', (data) => {
+        this.handleMessage(data);
+      });
+    });
+  }
+
+  /**
+   * Set up persistent event handlers after successful connection.
+   */
+  private setupHandlers(): void {
+    if (!this.ws) return;
+
+    // Remove the one-shot listeners from connect() and add persistent ones
+    this.ws.removeAllListeners('close');
+    this.ws.removeAllListeners('error');
+
+    this.ws.on('close', () => {
+      this.rejectAllPending(new Error('WebSocket connection closed'));
+      this.ws = null;
+      this.capabilities = null;
+    });
+
+    this.ws.on('error', (err) => {
+      console.error(`[BRIDGE] WebSocket error: ${err.message}`);
+      this.rejectAllPending(new Error(`WebSocket error: ${err.message}`));
+      this.ws = null;
+      this.capabilities = null;
+    });
+  }
+
+  /**
+   * Handle an incoming WebSocket message (JSON-RPC response).
+   */
+  private handleMessage(data: WebSocket.RawData): void {
+    let parsed: any;
+    try {
+      parsed = JSON.parse(data.toString());
+    } catch {
+      console.error('[BRIDGE] Received malformed JSON, ignoring');
+      return;
+    }
+
+    const id = parsed.id;
+    if (id === undefined || id === null) {
+      console.error('[BRIDGE] Received message without id, ignoring');
+      return;
+    }
+
+    const pending = this.pendingRequests.get(String(id));
+    if (!pending) {
+      console.error(`[BRIDGE] Received response for unknown request id: ${id}`);
+      return;
+    }
+
+    // Clear timeout and remove from pending map
+    clearTimeout(pending.timeout);
+    this.pendingRequests.delete(String(id));
+
+    if (parsed.error) {
+      pending.reject(new Error(`TestBridge error [${parsed.error.code}]: ${parsed.error.message}`));
+    } else {
+      pending.resolve(parsed.result);
+    }
+  }
+
+  /**
+   * Close the WebSocket connection and reject all pending requests.
+   */
+  disconnect(): void {
+    this.rejectAllPending(new Error('Disconnected from game'));
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
+        this.ws.close();
+      }
+      this.ws = null;
+    }
+    this.capabilities = null;
+  }
+
+  /**
+   * Send a JSON-RPC request to TestBridge and await the response.
+   *
+   * @param method - The JSON-RPC method name
+   * @param params - Optional parameters
+   * @param timeoutMs - Per-request timeout (default 5000ms). For wait tools, callers
+   *                    should pass params.timeout_ms + 2000 to avoid premature timeout.
+   */
+  send(method: string, params?: Record<string, unknown>, timeoutMs: number = 5000): Promise<unknown> {
+    if (!this.isConnected()) {
+      return Promise.reject(new Error('Not connected to game — call connect_to_game first'));
+    }
+
+    return new Promise((resolve, reject) => {
+      const id = randomUUID();
+
+      const timeout = setTimeout(() => {
+        // Guard against race condition: if response already arrived, do nothing
+        if (!this.pendingRequests.has(id)) return;
+        this.pendingRequests.delete(id);
+        reject(new Error(`Request '${method}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pendingRequests.set(id, { resolve, reject, timeout });
+
+      const message = JSON.stringify({ id, method, params: params ?? {} });
+      this.ws!.send(message);
+    });
+  }
+
+  /**
+   * Check if the WebSocket is currently connected.
+   */
+  isConnected(): boolean {
+    return this.ws !== null && this.ws.readyState === WebSocket.OPEN;
+  }
+
+  /**
+   * Get cached capabilities from the last hello handshake.
+   */
+  getCapabilities(): BridgeCapabilities | null {
+    return this.capabilities;
+  }
+
+  /**
+   * Reject all pending requests with the given error.
+   */
+  private rejectAllPending(error: Error): void {
+    for (const [id, pending] of this.pendingRequests) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pendingRequests.clear();
+  }
+}

--- a/src/e2e-tools.ts
+++ b/src/e2e-tools.ts
@@ -1,0 +1,814 @@
+/**
+ * E2E Testing Tools — MCP tool schemas, handlers, and dispatch for the E2E TestBridge.
+ *
+ * Exports getE2EToolSchemas(), handleE2ETool(), and getE2EParameterMappings()
+ * which are wired into GodotServer via index.ts.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+import { BridgeClient, BridgeCapabilities } from './bridge.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Context passed from GodotServer for tools that need server-level access.
+ */
+export interface ServerContext {
+  bridge: BridgeClient;
+  createErrorResponse: (message: string, possibleSolutions?: string[]) => any;
+  normalizeParameters: (params: Record<string, any>) => Record<string, any>;
+  godotPath: string | null;
+  setActiveProcess: (proc: any) => void;
+  getActiveProcess: () => any;
+}
+
+// ─── Path Validation ────────────────────────────────────────────────────────
+
+function validatePath(p: string): string | null {
+  if (p.includes('..')) return 'Path contains ".." traversal sequence';
+  return null;
+}
+
+// ─── Tool Schema Definitions ────────────────────────────────────────────────
+
+export function getE2EToolSchemas(): Array<{ name: string; description: string; inputSchema: any }> {
+  return [
+    // --- Connection Management ---
+    {
+      name: 'connect_to_game',
+      description: 'Connect to a running Godot instance\'s TestBridge WebSocket server.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          host: { type: 'string', description: 'Host address (default: localhost)', default: 'localhost' },
+          port: { type: 'number', description: 'WebSocket port (default: 9505)', default: 9505 },
+        },
+      },
+    },
+    {
+      name: 'disconnect_from_game',
+      description: 'Close the WebSocket connection to the running Godot instance gracefully.',
+      inputSchema: { type: 'object', properties: {} },
+    },
+    {
+      name: 'get_connection_status',
+      description: 'Check connection status and get game info (project name, capabilities, godot version).',
+      inputSchema: { type: 'object', properties: {} },
+    },
+
+    // --- Input Simulation ---
+    {
+      name: 'send_key',
+      description: 'Send a keyboard event to the running game. Supports modifier combos like "Ctrl+S". For games using Input Map actions, prefer send_input_action which triggers actions directly regardless of key bindings.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'Key name (e.g., "E", "Space", "Ctrl+Shift+S", "F1")' },
+          action: { type: 'string', enum: ['press', 'release', 'tap'], default: 'tap', description: 'Key action (default: tap = press + release)' },
+          hold_ms: { type: 'number', description: 'Hold duration in ms for tap action (default: 100)', default: 100 },
+        },
+        required: ['key'],
+      },
+    },
+    {
+      name: 'send_mouse_click',
+      description: 'Send a mouse click at screen coordinates.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          x: { type: 'number', description: 'X coordinate' },
+          y: { type: 'number', description: 'Y coordinate' },
+          button: { type: 'string', enum: ['left', 'right', 'middle'], default: 'left', description: 'Mouse button (default: left)' },
+        },
+        required: ['x', 'y'],
+      },
+    },
+    {
+      name: 'send_mouse_move',
+      description: 'Move the mouse cursor to screen coordinates.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          x: { type: 'number', description: 'Target X coordinate' },
+          y: { type: 'number', description: 'Target Y coordinate' },
+        },
+        required: ['x', 'y'],
+      },
+    },
+    {
+      name: 'send_mouse_drag',
+      description: 'Perform a mouse drag from one position to another over a duration.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          from_x: { type: 'number', description: 'Start X' },
+          from_y: { type: 'number', description: 'Start Y' },
+          to_x: { type: 'number', description: 'End X' },
+          to_y: { type: 'number', description: 'End Y' },
+          button: { type: 'string', enum: ['left', 'right', 'middle'], default: 'left' },
+          duration_ms: { type: 'number', description: 'Drag duration in ms (default: 500)', default: 500 },
+        },
+        required: ['from_x', 'from_y', 'to_x', 'to_y'],
+      },
+    },
+    {
+      name: 'send_input_action',
+      description: 'Trigger a named Godot Input Map action (e.g., "ui_accept", "move_left"). Preferred method for games using Godot Input Map. Directly triggers named actions so Input.is_action_pressed() returns true. Use this instead of send_key when the game uses Input Map actions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          action_name: { type: 'string', description: 'Godot Input Map action name' },
+          action: { type: 'string', enum: ['press', 'release', 'tap'], default: 'tap', description: 'Action type (default: tap = press + delayed release)' },
+          hold_ms: { type: 'number', description: 'Hold duration for tap (default: 100)', default: 100 },
+        },
+        required: ['action_name'],
+      },
+    },
+
+    // --- Scene Tree Inspection ---
+    {
+      name: 'get_scene_tree',
+      description: 'Get the scene tree structure as JSON. Returns node names, types, paths, visibility, and children.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          root_path: { type: 'string', description: 'Root node path (default: /root)', default: '/root' },
+          max_depth: { type: 'number', description: 'Maximum traversal depth (default: 4)', default: 4 },
+        },
+      },
+    },
+    {
+      name: 'get_node_properties',
+      description: 'Get property values from a specific node. Pass "*" for properties to get all properties.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          node_path: { type: 'string', description: 'Path to the node (e.g., "/root/Main/Player")' },
+          properties: {
+            description: 'Array of property names to read, or "*" for all properties',
+            oneOf: [
+              { type: 'array', items: { type: 'string' } },
+              { type: 'string', enum: ['*'] },
+            ],
+          },
+        },
+        required: ['node_path', 'properties'],
+      },
+    },
+    {
+      name: 'find_nodes',
+      description: 'Search for nodes by type, name pattern, or group membership.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', description: 'Class name filter (e.g., "Label", "CharacterBody2D")' },
+          name_pattern: { type: 'string', description: 'Glob pattern for node name (e.g., "Enemy*")' },
+          group: { type: 'string', description: 'Group name filter' },
+          root_path: { type: 'string', description: 'Root search path (default: /root)', default: '/root' },
+        },
+      },
+    },
+    {
+      name: 'get_viewport_info',
+      description: 'Get viewport info: size, mouse position, active camera details.',
+      inputSchema: { type: 'object', properties: {} },
+    },
+
+    // --- Game State Queries ---
+    {
+      name: 'call_method',
+      description: 'Call a method on a node and return the result. Works with GDScript and exported C# methods.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          node_path: { type: 'string', description: 'Path to target node' },
+          method_name: { type: 'string', description: 'Method to call' },
+          args: { type: 'array', description: 'Method arguments (default: [])', default: [] },
+        },
+        required: ['node_path', 'method_name'],
+      },
+    },
+    {
+      name: 'get_singleton',
+      description: 'Read properties from an autoload singleton (e.g., GameManager, AudioManager).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          singleton_name: { type: 'string', description: 'Autoload name (as registered in project.godot)' },
+          properties: { type: 'array', items: { type: 'string' }, description: 'Property names to read' },
+        },
+        required: ['singleton_name', 'properties'],
+      },
+    },
+    {
+      name: 'evaluate_expression',
+      description: 'Evaluate a GDScript expression at runtime. Requires TestBridge to be started with --unsafe flag. Powerful but dangerous — use only for testing.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          expression: { type: 'string', description: 'GDScript expression to evaluate (e.g., "2 + 2", "get_node(\\"/root/Main\\").position")' },
+          base_node_path: { type: 'string', description: 'Base node for expression context (default: /root)', default: '/root' },
+        },
+        required: ['expression'],
+      },
+    },
+
+    // --- Wait / Polling ---
+    {
+      name: 'wait_for_condition',
+      description: 'Poll a GDScript expression until it becomes truthy or times out. Returns whether the condition was satisfied and how long it took.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          expression: { type: 'string', description: 'GDScript expression that should eventually return truthy' },
+          timeout_ms: { type: 'number', description: 'Max wait time in ms (default: 5000)', default: 5000 },
+          poll_interval_ms: { type: 'number', description: 'Polling interval in ms (default: 100, min: 16)', default: 100 },
+          base_node_path: { type: 'string', description: 'Base node for expression context', default: '/root' },
+        },
+        required: ['expression'],
+      },
+    },
+    {
+      name: 'wait_frames',
+      description: 'Wait for a specific number of game frames to pass.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          count: { type: 'number', description: 'Number of frames to wait' },
+        },
+        required: ['count'],
+      },
+    },
+    {
+      name: 'wait_for_signal',
+      description: 'Wait for a signal to be emitted from a node, with timeout.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          node_path: { type: 'string', description: 'Path to the node that emits the signal' },
+          signal_name: { type: 'string', description: 'Signal name to wait for' },
+          timeout_ms: { type: 'number', description: 'Max wait time in ms (default: 5000)', default: 5000 },
+        },
+        required: ['node_path', 'signal_name'],
+      },
+    },
+
+    // --- Visual Verification ---
+    {
+      name: 'take_screenshot',
+      description: 'Capture a screenshot of the game viewport as base64 PNG. Response may be large. Requires a visible display (not headless).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          region: {
+            type: 'object',
+            description: 'Optional region to crop (x, y, width, height)',
+            properties: {
+              x: { type: 'number' },
+              y: { type: 'number' },
+              width: { type: 'number' },
+              height: { type: 'number' },
+            },
+          },
+        },
+      },
+    },
+    {
+      name: 'get_pixel_color',
+      description: 'Get the RGBA color of a pixel at specific coordinates. Values are 0.0-1.0. Requires a visible display.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          x: { type: 'number', description: 'X coordinate' },
+          y: { type: 'number', description: 'Y coordinate' },
+        },
+        required: ['x', 'y'],
+      },
+    },
+
+    // --- Test Orchestration ---
+    {
+      name: 'run_project_with_bridge',
+      description: 'Launch a Godot project with TestBridge enabled and automatically connect. Combines run_project + connect_to_game in one step.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Path to Godot project directory' },
+          scene: { type: 'string', description: 'Optional scene to run (e.g., "res://main.tscn")' },
+          port: { type: 'number', description: 'TestBridge port (default: 9505)', default: 9505 },
+          timeout_ms: { type: 'number', description: 'Max time to wait for connection in ms (default: 10000)', default: 10000 },
+        },
+        required: ['project_path'],
+      },
+    },
+    {
+      name: 'reset_scene',
+      description: 'Reload the current scene to a clean state. Warning: any pending wait_for_condition or wait_for_signal calls will fail as their target nodes are destroyed during reload.',
+      inputSchema: { type: 'object', properties: {} },
+    },
+    {
+      name: 'load_scene',
+      description: 'Switch to a different scene. Warning: any pending wait_for_condition or wait_for_signal calls will fail as their target nodes are destroyed during scene change.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          scene_path: { type: 'string', description: 'Scene resource path (e.g., "res://levels/level2.tscn")' },
+        },
+        required: ['scene_path'],
+      },
+    },
+    {
+      name: 'install_test_bridge',
+      description: 'Install TestBridge.gd into a Godot project and register it as an autoload. Copies the file to addons/test_bridge/ and updates project.godot.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Path to the Godot project directory' },
+        },
+        required: ['project_path'],
+      },
+    },
+  ];
+}
+
+// ─── Parameter Mappings ─────────────────────────────────────────────────────
+
+export function getE2EParameterMappings(): Record<string, string> {
+  return {
+    'action_name': 'actionName',
+    'hold_ms': 'holdMs',
+    'from_x': 'fromX',
+    'from_y': 'fromY',
+    'to_x': 'toX',
+    'to_y': 'toY',
+    'duration_ms': 'durationMs',
+    'root_path': 'rootPath',
+    'max_depth': 'maxDepth',
+    'node_path': 'nodePath',
+    'name_pattern': 'namePattern',
+    'method_name': 'methodName',
+    'singleton_name': 'singletonName',
+    'base_node_path': 'baseNodePath',
+    'timeout_ms': 'timeoutMs',
+    'poll_interval_ms': 'pollIntervalMs',
+    'signal_name': 'signalName',
+    'project_path': 'projectPath',
+    'scene_path': 'scenePath',
+  };
+}
+
+// ─── Tool Dispatch ──────────────────────────────────────────────────────────
+
+export async function handleE2ETool(
+  name: string,
+  args: Record<string, any> | undefined,
+  context: ServerContext,
+): Promise<any> {
+  const params = context.normalizeParameters(args ?? {});
+  const { bridge, createErrorResponse } = context;
+
+  switch (name) {
+    // Connection Management
+    case 'connect_to_game':
+      return handleConnectToGame(params, bridge, createErrorResponse);
+    case 'disconnect_from_game':
+      return handleDisconnectFromGame(bridge);
+    case 'get_connection_status':
+      return handleGetConnectionStatus(bridge);
+
+    // Input Simulation
+    case 'send_key':
+    case 'send_mouse_click':
+    case 'send_mouse_move':
+    case 'send_mouse_drag':
+    case 'send_input_action':
+      return handleBridgePassthrough(name, params, bridge, createErrorResponse, 'input');
+
+    // Scene Tree Inspection
+    case 'get_scene_tree':
+    case 'get_node_properties':
+    case 'find_nodes':
+    case 'get_viewport_info':
+      return handleBridgePassthrough(name, params, bridge, createErrorResponse, 'scene_tree');
+
+    // Game State
+    case 'call_method':
+    case 'get_singleton':
+      return handleBridgePassthrough(name, params, bridge, createErrorResponse, 'state');
+    case 'evaluate_expression':
+      return handleEvaluateExpression(params, bridge, createErrorResponse);
+
+    // Wait / Polling
+    case 'wait_for_condition':
+    case 'wait_for_signal':
+      return handleWaitTool(name, params, bridge, createErrorResponse);
+    case 'wait_frames':
+      return handleBridgePassthrough(name, params, bridge, createErrorResponse, 'wait');
+
+    // Visual Verification
+    case 'take_screenshot':
+    case 'get_pixel_color':
+      return handleBridgePassthrough(name, params, bridge, createErrorResponse, 'screenshot');
+
+    // Test Orchestration
+    case 'run_project_with_bridge':
+      return handleRunProjectWithBridge(params, context);
+    case 'reset_scene':
+    case 'load_scene':
+      return handleBridgePassthrough(name, params, bridge, createErrorResponse);
+    case 'install_test_bridge':
+      return handleInstallTestBridge(params, createErrorResponse);
+
+    default:
+      return null; // Not an E2E tool — let caller handle
+  }
+}
+
+// ─── Helper: Success Response ───────────────────────────────────────────────
+
+function successResponse(data: any): any {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+// ─── Helper: Convert camelCase params back to snake_case for TestBridge ─────
+
+let _cachedReverseMap: Record<string, string> | null = null;
+
+function getReverseParamMap(): Record<string, string> {
+  if (!_cachedReverseMap) {
+    _cachedReverseMap = {};
+    const mappings = getE2EParameterMappings();
+    for (const [snake, camel] of Object.entries(mappings)) {
+      _cachedReverseMap[camel] = snake;
+    }
+  }
+  return _cachedReverseMap;
+}
+
+function toSnakeCaseParams(params: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {};
+  const reverseMap = getReverseParamMap();
+  for (const [key, val] of Object.entries(params)) {
+    const snakeKey = reverseMap[key] ?? key;
+    result[snakeKey] = val;
+  }
+  return result;
+}
+
+// ─── Connection Handlers ────────────────────────────────────────────────────
+
+async function handleConnectToGame(
+  params: Record<string, any>,
+  bridge: BridgeClient,
+  createErrorResponse: (msg: string, solutions?: string[]) => any,
+): Promise<any> {
+  const host = params.host ?? 'localhost';
+  const port = params.port ?? 9505;
+
+  try {
+    const caps = await bridge.connect(host, port);
+    return successResponse({ connected: true, ...caps });
+  } catch (err: any) {
+    return createErrorResponse(
+      `Failed to connect to TestBridge at ${host}:${port}: ${err.message}`,
+      [
+        'Ensure Godot is running with --test-bridge flag',
+        'Check that TestBridge is installed (use install_test_bridge)',
+        'Verify the port is correct (default: 9505)',
+      ],
+    );
+  }
+}
+
+async function handleDisconnectFromGame(bridge: BridgeClient): Promise<any> {
+  bridge.disconnect();
+  return successResponse({ disconnected: true });
+}
+
+async function handleGetConnectionStatus(bridge: BridgeClient): Promise<any> {
+  if (bridge.isConnected()) {
+    const caps = bridge.getCapabilities();
+    return successResponse({ connected: true, ...caps });
+  }
+  return successResponse({ connected: false });
+}
+
+// ─── Generic Bridge Passthrough ─────────────────────────────────────────────
+
+async function handleBridgePassthrough(
+  method: string,
+  params: Record<string, any>,
+  bridge: BridgeClient,
+  createErrorResponse: (msg: string, solutions?: string[]) => any,
+  requiredCapability?: string,
+): Promise<any> {
+  if (!bridge.isConnected()) {
+    return createErrorResponse(
+      'Not connected to game',
+      ['Call connect_to_game or run_project_with_bridge first'],
+    );
+  }
+
+  if (requiredCapability) {
+    const caps = bridge.getCapabilities();
+    if (caps && !caps.capabilities.includes(requiredCapability)) {
+      return createErrorResponse(
+        `Game does not support '${requiredCapability}' capability`,
+        ['Check get_connection_status for available capabilities'],
+      );
+    }
+  }
+
+  try {
+    const snakeParams = toSnakeCaseParams(params);
+    const result = await bridge.send(method, snakeParams);
+    return successResponse(result);
+  } catch (err: any) {
+    return createErrorResponse(err.message);
+  }
+}
+
+// ─── Evaluate Expression ────────────────────────────────────────────────────
+
+async function handleEvaluateExpression(
+  params: Record<string, any>,
+  bridge: BridgeClient,
+  createErrorResponse: (msg: string, solutions?: string[]) => any,
+): Promise<any> {
+  if (!bridge.isConnected()) {
+    return createErrorResponse('Not connected to game', ['Call connect_to_game first']);
+  }
+
+  const caps = bridge.getCapabilities();
+  if (caps && !caps.capabilities.includes('evaluate')) {
+    return createErrorResponse(
+      'evaluate_expression requires the --unsafe flag on TestBridge',
+      ['Start the game with: --test-bridge --unsafe'],
+    );
+  }
+
+  try {
+    const snakeParams = toSnakeCaseParams(params);
+    const result = await bridge.send('evaluate_expression', snakeParams);
+    return successResponse(result);
+  } catch (err: any) {
+    return createErrorResponse(err.message);
+  }
+}
+
+// ─── Wait Tools (extended timeout) ──────────────────────────────────────────
+
+async function handleWaitTool(
+  method: string,
+  params: Record<string, any>,
+  bridge: BridgeClient,
+  createErrorResponse: (msg: string, solutions?: string[]) => any,
+): Promise<any> {
+  if (!bridge.isConnected()) {
+    return createErrorResponse('Not connected to game', ['Call connect_to_game first']);
+  }
+
+  const caps = bridge.getCapabilities();
+  if (caps && !caps.capabilities.includes('wait')) {
+    return createErrorResponse('Game does not support wait capability');
+  }
+
+  // wait_for_condition uses Expression evaluation — requires --unsafe
+  if (method === 'wait_for_condition' && caps && !caps.capabilities.includes('evaluate')) {
+    return createErrorResponse(
+      'wait_for_condition uses expression evaluation and requires --unsafe flag on TestBridge',
+      ['Start the game with: --test-bridge --unsafe'],
+    );
+  }
+
+  // Extended timeout: Godot-side timeout + 2s buffer for network/processing
+  const godotTimeout = params.timeoutMs ?? 5000;
+  const bridgeTimeout = godotTimeout + 2000;
+
+  try {
+    const snakeParams = toSnakeCaseParams(params);
+    const result = await bridge.send(method, snakeParams, bridgeTimeout);
+    return successResponse(result);
+  } catch (err: any) {
+    return createErrorResponse(err.message);
+  }
+}
+
+// ─── Run Project With Bridge ────────────────────────────────────────────────
+
+async function handleRunProjectWithBridge(
+  params: Record<string, any>,
+  context: ServerContext,
+): Promise<any> {
+  const { bridge, createErrorResponse, godotPath, setActiveProcess } = context;
+
+  if (!godotPath) {
+    return createErrorResponse('Godot path not configured', ['Set GODOT_PATH or let the server auto-detect']);
+  }
+
+  const projectPath = params.projectPath;
+  if (!projectPath) {
+    return createErrorResponse('Missing required parameter: project_path');
+  }
+  const pathErr = validatePath(projectPath);
+  if (pathErr) {
+    return createErrorResponse(`Invalid project_path: ${pathErr}`);
+  }
+
+  const port = params.port ?? 9505;
+  const timeoutMs = params.timeoutMs ?? 10000;
+  const scene = params.scene;
+
+  // Build Godot CLI args
+  const godotArgs = ['-d', '--path', projectPath];
+  if (scene) {
+    godotArgs.push('--scene', scene);
+  }
+  // Args after -- go to the game
+  godotArgs.push('--', '--test-bridge', `--test-bridge-port=${port}`);
+
+  return new Promise((resolve) => {
+    const output: string[] = [];
+    const errors: string[] = [];
+    let settled = false; // Unified guard: resolve() only once
+    let connecting = false; // Reentrancy guard for stdout handler
+
+    const settle = (result: any) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      resolve(result);
+    };
+
+    const proc = spawn(godotPath, godotArgs);
+
+    // Register as active process so stop_project can kill it
+    const activeProc = { process: proc, output, errors };
+    setActiveProcess(activeProc);
+
+    // Overall timeout
+    const timeoutTimer = setTimeout(() => {
+      if (!settled) {
+        proc.kill();
+        settle(createErrorResponse(
+          `Timed out waiting for TestBridge after ${timeoutMs}ms`,
+          [
+            'Ensure TestBridge is installed in the project',
+            'Check stderr output: ' + errors.join('\n').slice(0, 500),
+          ],
+        ));
+      }
+    }, timeoutMs);
+
+    proc.stdout.on('data', async (data: Buffer) => {
+      const text = data.toString();
+      output.push(text);
+
+      // Check for error signal
+      const errorMatch = text.match(/TESTBRIDGE_ERROR:(\w+):(\d+)/);
+      if (errorMatch) {
+        settle(createErrorResponse(
+          `TestBridge failed to start: ${errorMatch[1]} on port ${errorMatch[2]}`,
+          ['Try a different port', 'Check if another instance is using the port'],
+        ));
+        return;
+      }
+
+      // Check for ready signal — reentrancy guard prevents parallel backoff loops
+      const readyMatch = text.match(/TESTBRIDGE_READY:(\d+)/);
+      if (readyMatch && !settled && !connecting) {
+        connecting = true;
+        const readyPort = parseInt(readyMatch[1], 10);
+        console.error(`[E2E] TestBridge ready on port ${readyPort}`);
+
+        // Wait briefly for TCP server to stabilize, then connect with backoff
+        await new Promise(r => setTimeout(r, 500));
+
+        const backoffDelays = [200, 400, 800, 1600, 3200];
+        for (const delay of backoffDelays) {
+          if (settled) break;
+          try {
+            const caps = await bridge.connect('localhost', readyPort);
+            settle(successResponse({
+              connected: true,
+              port: readyPort,
+              project: caps.project_name,
+              ...caps,
+            }));
+            return;
+          } catch {
+            console.error(`[E2E] Connection attempt failed, retrying in ${delay}ms...`);
+            await new Promise(r => setTimeout(r, delay));
+          }
+        }
+
+        if (!settled) {
+          settle(createErrorResponse(
+            'TestBridge ready but could not establish WebSocket connection',
+            ['Port may be blocked', 'TestBridge may have crashed after startup'],
+          ));
+        }
+      }
+    });
+
+    proc.stderr.on('data', (data: Buffer) => {
+      errors.push(data.toString());
+    });
+
+    proc.on('exit', (code) => {
+      if (!settled) {
+        settle(createErrorResponse(
+          `Godot process exited with code ${code} before TestBridge was ready`,
+          [
+            'Check project path and scene',
+            'Stderr: ' + errors.join('\n').slice(0, 500),
+          ],
+        ));
+      }
+    });
+
+    proc.on('error', (err) => {
+      settle(createErrorResponse(
+        `Failed to spawn Godot: ${err.message}`,
+        ['Verify GODOT_PATH is correct'],
+      ));
+    });
+  });
+}
+
+// ─── Install Test Bridge ────────────────────────────────────────────────────
+
+async function handleInstallTestBridge(
+  params: Record<string, any>,
+  createErrorResponse: (msg: string, solutions?: string[]) => any,
+): Promise<any> {
+  const projectPath = params.projectPath;
+  if (!projectPath) {
+    return createErrorResponse('Missing required parameter: project_path');
+  }
+  const installPathErr = validatePath(projectPath);
+  if (installPathErr) {
+    return createErrorResponse(`Invalid project_path: ${installPathErr}`);
+  }
+
+  const projectGodot = join(projectPath, 'project.godot');
+  if (!existsSync(projectGodot)) {
+    return createErrorResponse(
+      `No project.godot found at ${projectPath}`,
+      ['Verify the path points to a valid Godot project directory'],
+    );
+  }
+
+  // 1. Copy test_bridge.gd to project
+  const sourceGd = join(__dirname, 'scripts', 'test_bridge.gd');
+  if (!existsSync(sourceGd)) {
+    return createErrorResponse(
+      'test_bridge.gd not found in godot-mcp build',
+      ['Run npm run build first'],
+    );
+  }
+
+  const targetDir = join(projectPath, 'addons', 'test_bridge');
+  mkdirSync(targetDir, { recursive: true });
+  copyFileSync(sourceGd, join(targetDir, 'TestBridge.gd'));
+
+  // 2. Update project.godot — append-only strategy
+  let content = readFileSync(projectGodot, 'utf-8');
+
+  const autoloadSection = /^\[autoload\]\s*$/m;
+  const testBridgeLine = 'TestBridge="*res://addons/test_bridge/TestBridge.gd"';
+
+  if (autoloadSection.test(content)) {
+    // Check if TestBridge already registered
+    if (content.includes('TestBridge=')) {
+      // Already installed — update the line in case the path changed
+      content = content.replace(
+        /^TestBridge=.*$/m,
+        testBridgeLine,
+      );
+    } else {
+      // Append after [autoload] header
+      content = content.replace(
+        /^\[autoload\]\s*$/m,
+        `[autoload]\n${testBridgeLine}`,
+      );
+    }
+  } else {
+    // No autoload section — append at end
+    content += `\n[autoload]\n\n${testBridgeLine}\n`;
+  }
+
+  writeFileSync(projectGodot, content, 'utf-8');
+
+  return successResponse({
+    installed: true,
+    path: 'res://addons/test_bridge/TestBridge.gd',
+    autoload_registered: true,
+  });
+}

--- a/src/scripts/test_bridge.gd
+++ b/src/scripts/test_bridge.gd
@@ -1,0 +1,1080 @@
+## TestBridge — E2E testing bridge for godot-mcp.
+##
+## Autoload that starts a WebSocket server when activated via --test-bridge CLI flag
+## or TEST_BRIDGE=true env var. Receives JSON-RPC commands from the MCP server
+## for input injection, scene inspection, state queries, and visual verification.
+extends Node
+
+# --- Configuration ---
+var _port: int = 9505
+var _active: bool = false
+var _unsafe_mode: bool = false
+var _debug: bool = false
+
+# --- Networking ---
+var _tcp_server: TCPServer = null
+var _ws_peer: WebSocketPeer = null
+var _tcp_peer: StreamPeerTCP = null
+
+# --- Concurrency ---
+## Maps request ID → true for in-flight async operations.
+## _process() never blocks; async handlers use coroutines and call
+## _send_response() when complete.
+var _pending_responses: Dictionary = {}
+
+# --- Key lookup ---
+var _key_map: Dictionary = {}
+
+# --- Lifecycle ---
+
+func _ready() -> void:
+	# Check activation flags
+	var args := OS.get_cmdline_args() + OS.get_cmdline_user_args()
+	var env_flag := OS.get_environment("TEST_BRIDGE")
+
+	if "--test-bridge" not in args and env_flag != "true":
+		return
+
+	_active = true
+	_unsafe_mode = "--unsafe" in args
+	_debug = "--test-bridge-debug" in args
+
+	# Parse port override
+	for arg in args:
+		if arg.begins_with("--test-bridge-port="):
+			var port_str := arg.split("=")[1]
+			if port_str.is_valid_int():
+				_port = int(port_str)
+
+	_build_key_map()
+	_start_server()
+
+
+func _start_server() -> void:
+	_tcp_server = TCPServer.new()
+	var err := _tcp_server.listen(_port)
+	if err != OK:
+		print("TESTBRIDGE_ERROR:port_in_use:%d" % _port)
+		printerr("[TestBridge] Failed to listen on port %d: error %d" % [_port, err])
+		_active = false
+		return
+
+	print("TESTBRIDGE_READY:%d" % _port)
+	_log_debug("TestBridge listening on port %d (unsafe=%s)" % [_port, str(_unsafe_mode)])
+
+
+func _process(_delta: float) -> void:
+	if not _active:
+		return
+
+	# Accept new TCP connections
+	if _tcp_server and _tcp_server.is_connection_available():
+		var new_tcp := _tcp_server.take_connection()
+		if new_tcp:
+			# Close existing peer if any
+			if _ws_peer:
+				_ws_peer.close()
+				_ws_peer = null
+				_log_debug("Closed previous WebSocket peer for new connection")
+			_tcp_peer = new_tcp
+			_ws_peer = WebSocketPeer.new()
+			var err := _ws_peer.accept_stream(_tcp_peer)
+			if err != OK:
+				printerr("[TestBridge] Failed to accept WebSocket stream: %d" % err)
+				_ws_peer = null
+				_tcp_peer = null
+			else:
+				_log_debug("New WebSocket client connected")
+
+	# Poll existing WebSocket peer
+	if _ws_peer:
+		_ws_peer.poll()
+		var state := _ws_peer.get_ready_state()
+
+		if state == WebSocketPeer.STATE_OPEN:
+			while _ws_peer.get_available_packet_count() > 0:
+				var packet := _ws_peer.get_packet()
+				var text := packet.get_string_from_utf8()
+				_handle_packet(text)
+
+		elif state == WebSocketPeer.STATE_CLOSED:
+			_log_debug("WebSocket client disconnected")
+			_ws_peer = null
+			_tcp_peer = null
+
+
+# --- JSON-RPC Dispatch ---
+
+func _handle_packet(text: String) -> void:
+	var parsed = JSON.parse_string(text)
+	if parsed == null:
+		_send_raw_response(null, null, {"code": -32700, "message": "Parse error: invalid JSON"})
+		return
+
+	if typeof(parsed) != TYPE_DICTIONARY:
+		_send_raw_response(null, null, {"code": -32700, "message": "Parse error: expected JSON object"})
+		return
+
+	var id = parsed.get("id")
+	var method: String = parsed.get("method", "")
+	var params = parsed.get("params", {})
+
+	if method.is_empty():
+		_send_raw_response(id, null, {"code": -32600, "message": "Invalid request: missing method"})
+		return
+
+	_dispatch(id, method, params)
+
+
+func _dispatch(id, method: String, params: Dictionary) -> void:
+	match method:
+		"hello":
+			_handle_hello(id, params)
+		"send_key":
+			_handle_send_key(id, params)
+		"send_mouse_click":
+			_handle_send_mouse_click(id, params)
+		"send_mouse_move":
+			_handle_send_mouse_move(id, params)
+		"send_mouse_drag":
+			_handle_send_mouse_drag(id, params)
+		"send_input_action":
+			_handle_send_input_action(id, params)
+		"get_scene_tree":
+			_handle_get_scene_tree(id, params)
+		"get_node_properties":
+			_handle_get_node_properties(id, params)
+		"find_nodes":
+			_handle_find_nodes(id, params)
+		"get_viewport_info":
+			_handle_get_viewport_info(id, params)
+		"call_method":
+			_handle_call_method(id, params)
+		"get_singleton":
+			_handle_get_singleton(id, params)
+		"evaluate_expression":
+			_handle_evaluate_expression(id, params)
+		"wait_for_condition":
+			_handle_wait_for_condition(id, params)
+		"wait_frames":
+			_handle_wait_frames(id, params)
+		"wait_for_signal":
+			_handle_wait_for_signal(id, params)
+		"take_screenshot":
+			_handle_take_screenshot(id, params)
+		"get_pixel_color":
+			_handle_get_pixel_color(id, params)
+		"reset_scene":
+			_handle_reset_scene(id, params)
+		"load_scene":
+			_handle_load_scene(id, params)
+		_:
+			_send_error(id, -32601, "Method not found: %s" % method)
+
+
+# --- Response Helpers ---
+
+func _send_response(id, result) -> void:
+	_send_raw_response(id, result, null)
+	_pending_responses.erase(str(id))
+
+
+func _send_error(id, code: int, message: String) -> void:
+	_send_raw_response(id, null, {"code": code, "message": message})
+	_pending_responses.erase(str(id))
+
+
+func _send_raw_response(id, result, error) -> void:
+	if not _ws_peer or _ws_peer.get_ready_state() != WebSocketPeer.STATE_OPEN:
+		return
+	var response := {}
+	response["id"] = id
+	if error != null:
+		response["error"] = error
+	else:
+		response["result"] = result
+	_ws_peer.send_text(JSON.stringify(response))
+
+
+# --- Handler: hello ---
+
+func _handle_hello(id, _params: Dictionary) -> void:
+	var caps := ["input", "scene_tree", "state", "wait"]
+
+	# Visual capabilities depend on display mode
+	if DisplayServer.get_name() != "headless":
+		caps.append("screenshot")
+
+	# Evaluate capability depends on unsafe mode
+	if _unsafe_mode:
+		caps.append("evaluate")
+
+	# C# interop detection
+	if ClassDB.class_exists("CSharpScript"):
+		caps.append("csharp_interop")
+
+	# Avalonia detection — check if any AvaloniaControl node exists
+	if _find_avalonia_nodes().size() > 0:
+		caps.append("avalonia_input")
+
+	_send_response(id, {
+		"protocol_version": "1.0",
+		"capabilities": caps,
+		"unsafe_mode": _unsafe_mode,
+		"godot_version": Engine.get_version_info().string,
+		"project_name": ProjectSettings.get_setting("application/config/name", ""),
+		"display_mode": DisplayServer.get_name()
+	})
+
+
+# --- Handlers: Input Simulation ---
+
+func _handle_send_key(id, params: Dictionary) -> void:
+	var key_string: String = params.get("key", "")
+	if key_string.is_empty():
+		_send_error(id, -32602, "Missing required parameter: key")
+		return
+
+	var action: String = params.get("action", "tap")
+	var hold_ms: int = int(params.get("hold_ms", 100))
+
+	# Parse modifiers and key name
+	var parts := key_string.split("+")
+	var key_name := parts[-1]
+	var ctrl := false
+	var shift := false
+	var alt := false
+	var meta := false
+
+	for i in range(parts.size() - 1):
+		var mod := parts[i].strip_edges()
+		match mod:
+			"Ctrl":
+				ctrl = true
+			"Shift":
+				shift = true
+			"Alt":
+				alt = true
+			"Meta":
+				meta = true
+
+	# Resolve keycode
+	var keycode = _key_map.get(key_name, null)
+	if keycode == null:
+		# Try single character A-Z
+		if key_name.length() == 1:
+			var ch := key_name.to_upper()
+			if ch >= "A" and ch <= "Z":
+				keycode = ch.unicode_at(0)
+			elif ch >= "0" and ch <= "9":
+				keycode = ch.unicode_at(0)
+		if keycode == null:
+			var valid_keys := ", ".join(_key_map.keys())
+			_send_error(id, -32602, "Unknown key: %s. Valid keys: A-Z, 0-9, %s" % [key_name, valid_keys])
+			return
+
+	match action:
+		"press":
+			_inject_key(keycode, true, ctrl, shift, alt, meta)
+			_send_response(id, {"action": "press", "key": key_string})
+		"release":
+			_inject_key(keycode, false, ctrl, shift, alt, meta)
+			_send_response(id, {"action": "release", "key": key_string})
+		"tap":
+			_pending_responses[str(id)] = true
+			_inject_key(keycode, true, ctrl, shift, alt, meta)
+			await get_tree().create_timer(hold_ms / 1000.0).timeout
+			_inject_key(keycode, false, ctrl, shift, alt, meta)
+			_send_response(id, {"action": "tap", "key": key_string})
+		_:
+			_send_error(id, -32602, "Invalid action: %s. Must be press, release, or tap" % action)
+
+
+func _inject_key(keycode: int, pressed: bool, ctrl: bool, shift: bool, alt: bool, meta: bool) -> void:
+	var event := InputEventKey.new()
+	event.keycode = keycode
+	event.pressed = pressed
+	event.ctrl_pressed = ctrl
+	event.shift_pressed = shift
+	event.alt_pressed = alt
+	event.meta_pressed = meta
+	Input.parse_input_event(event)
+
+
+func _handle_send_mouse_click(id, params: Dictionary) -> void:
+	if not params.has("x") or not params.has("y"):
+		_send_error(id, -32602, "Missing required parameters: x, y")
+		return
+
+	var pos := Vector2(float(params.x), float(params.y))
+	var button_name: String = params.get("button", "left")
+	var button_index := _resolve_mouse_button(button_name)
+	if button_index == 0:
+		_send_error(id, -32602, "Invalid button: %s. Must be left, right, or middle" % button_name)
+		return
+
+	# Press
+	var press_event := InputEventMouseButton.new()
+	press_event.position = pos
+	press_event.global_position = pos
+	press_event.button_index = button_index
+	press_event.pressed = true
+	Input.parse_input_event(press_event)
+
+	# Try Avalonia forwarding
+	_try_avalonia_input(pos, press_event)
+
+	# Deferred release
+	get_tree().create_timer(0.05).timeout.connect(func():
+		var release_event := InputEventMouseButton.new()
+		release_event.position = pos
+		release_event.global_position = pos
+		release_event.button_index = button_index
+		release_event.pressed = false
+		Input.parse_input_event(release_event)
+	)
+
+	_send_response(id, {"action": "click", "x": pos.x, "y": pos.y, "button": button_name})
+
+
+func _handle_send_mouse_move(id, params: Dictionary) -> void:
+	if not params.has("x") or not params.has("y"):
+		_send_error(id, -32602, "Missing required parameters: x, y")
+		return
+
+	var pos := Vector2(float(params.x), float(params.y))
+	var current_pos := get_viewport().get_mouse_position()
+
+	var event := InputEventMouseMotion.new()
+	event.position = pos
+	event.global_position = pos
+	event.relative = pos - current_pos
+	Input.parse_input_event(event)
+
+	_send_response(id, {"x": pos.x, "y": pos.y})
+
+
+func _handle_send_mouse_drag(id, params: Dictionary) -> void:
+	if not params.has("from_x") or not params.has("from_y") or not params.has("to_x") or not params.has("to_y"):
+		_send_error(id, -32602, "Missing required parameters: from_x, from_y, to_x, to_y")
+		return
+
+	var from_pos := Vector2(float(params.from_x), float(params.from_y))
+	var to_pos := Vector2(float(params.to_x), float(params.to_y))
+	var button_name: String = params.get("button", "left")
+	var duration_ms: int = int(params.get("duration_ms", 500))
+	var button_index := _resolve_mouse_button(button_name)
+	if button_index == 0:
+		_send_error(id, -32602, "Invalid button: %s" % button_name)
+		return
+
+	# Mark as async
+	_pending_responses[str(id)] = true
+	_do_mouse_drag(id, from_pos, to_pos, button_index, duration_ms)
+
+
+func _do_mouse_drag(id, from_pos: Vector2, to_pos: Vector2, button_index: int, duration_ms: int) -> void:
+	# Move to start
+	var move_event := InputEventMouseMotion.new()
+	move_event.position = from_pos
+	move_event.global_position = from_pos
+	Input.parse_input_event(move_event)
+
+	# Press
+	var press_event := InputEventMouseButton.new()
+	press_event.position = from_pos
+	press_event.global_position = from_pos
+	press_event.button_index = button_index
+	press_event.pressed = true
+	Input.parse_input_event(press_event)
+
+	# Interpolate over frames
+	var steps := max(1, duration_ms / 16)  # ~60fps
+	for i in range(1, steps + 1):
+		var t := float(i) / float(steps)
+		var pos := from_pos.lerp(to_pos, t)
+		var drag_event := InputEventMouseMotion.new()
+		drag_event.position = pos
+		drag_event.global_position = pos
+		drag_event.relative = (to_pos - from_pos) / float(steps)
+		drag_event.button_mask = _resolve_button_mask(button_index)
+		Input.parse_input_event(drag_event)
+		await get_tree().create_timer(0.016).timeout
+
+	# Release
+	var release_event := InputEventMouseButton.new()
+	release_event.position = to_pos
+	release_event.global_position = to_pos
+	release_event.button_index = button_index
+	release_event.pressed = false
+	Input.parse_input_event(release_event)
+
+	_send_response(id, {"action": "drag", "from": {"x": from_pos.x, "y": from_pos.y}, "to": {"x": to_pos.x, "y": to_pos.y}})
+
+
+func _handle_send_input_action(id, params: Dictionary) -> void:
+	var action_name: String = params.get("action_name", "")
+	if action_name.is_empty():
+		_send_error(id, -32602, "Missing required parameter: action_name")
+		return
+
+	var action: String = params.get("action", "tap")
+	var hold_ms: int = int(params.get("hold_ms", 100))
+
+	match action:
+		"press":
+			Input.action_press(action_name)
+			_send_response(id, {"action": "press", "action_name": action_name})
+		"release":
+			Input.action_release(action_name)
+			_send_response(id, {"action": "release", "action_name": action_name})
+		"tap":
+			Input.action_press(action_name)
+			_send_response(id, {"action": "tap", "action_name": action_name})
+			get_tree().create_timer(hold_ms / 1000.0).timeout.connect(
+				func(): Input.action_release(action_name)
+			)
+		_:
+			_send_error(id, -32602, "Invalid action: %s. Must be press, release, or tap" % action)
+
+
+func _resolve_mouse_button(name: String) -> int:
+	match name:
+		"left":
+			return MOUSE_BUTTON_LEFT
+		"right":
+			return MOUSE_BUTTON_RIGHT
+		"middle":
+			return MOUSE_BUTTON_MIDDLE
+		_:
+			return 0
+
+
+func _resolve_button_mask(button_index: int) -> int:
+	match button_index:
+		MOUSE_BUTTON_LEFT:
+			return MOUSE_BUTTON_MASK_LEFT
+		MOUSE_BUTTON_RIGHT:
+			return MOUSE_BUTTON_MASK_RIGHT
+		MOUSE_BUTTON_MIDDLE:
+			return MOUSE_BUTTON_MASK_MIDDLE
+		_:
+			return 0
+
+
+# --- Handlers: Scene Tree Inspection ---
+
+func _handle_get_scene_tree(id, params: Dictionary) -> void:
+	var root_path: String = params.get("root_path", "/root")
+	var max_depth: int = int(params.get("max_depth", 4))
+
+	var root_node := get_node_or_null(root_path)
+	if root_node == null:
+		_send_error(id, -32602, "Node not found: %s" % root_path)
+		return
+
+	var tree := _build_tree(root_node, 0, max_depth)
+	_send_response(id, tree)
+
+
+func _build_tree(node: Node, depth: int, max_depth: int) -> Dictionary:
+	var result := {
+		"name": node.name,
+		"type": node.get_class(),
+		"path": str(node.get_path()),
+	}
+
+	if node is CanvasItem:
+		result["visible"] = node.visible
+	elif node is Node3D:
+		result["visible"] = node.visible
+
+	if depth < max_depth:
+		var children := []
+		for child in node.get_children():
+			children.append(_build_tree(child, depth + 1, max_depth))
+		result["children"] = children
+	else:
+		result["children"] = []
+
+	return result
+
+
+func _handle_get_node_properties(id, params: Dictionary) -> void:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		_send_error(id, -32602, "Missing required parameter: node_path")
+		return
+
+	var node := get_node_or_null(node_path)
+	if node == null:
+		_send_error(id, -32602, "Node not found: %s" % node_path)
+		return
+
+	var properties = params.get("properties", [])
+	var result := {}
+	var is_csharp := _is_csharp_node(node)
+
+	if typeof(properties) == TYPE_STRING and properties == "*":
+		# Get all properties
+		for prop_info in node.get_property_list():
+			var prop_name: String = prop_info.name
+			result[prop_name] = _variant_to_json(node.get(prop_name))
+	elif typeof(properties) == TYPE_ARRAY:
+		for prop_name in properties:
+			var val = node.get(prop_name)
+			if val == null and is_csharp:
+				# C# getter fallback
+				var getter_name := "Get" + _to_pascal_case(prop_name)
+				if node.has_method(getter_name):
+					val = node.call(getter_name)
+				else:
+					result[prop_name] = {"_error": "property not accessible from GDScript"}
+					continue
+			result[prop_name] = _variant_to_json(val)
+	else:
+		_send_error(id, -32602, "properties must be an array of strings or \"*\"")
+		return
+
+	_send_response(id, result)
+
+
+func _handle_find_nodes(id, params: Dictionary) -> void:
+	var root_path: String = params.get("root_path", "/root")
+	var type_filter: String = params.get("type", "")
+	var name_pattern: String = params.get("name_pattern", "")
+	var group_filter: String = params.get("group", "")
+
+	var root_node := get_node_or_null(root_path)
+	if root_node == null:
+		_send_error(id, -32602, "Node not found: %s" % root_path)
+		return
+
+	var results := []
+	_find_nodes_recursive(root_node, type_filter, name_pattern, group_filter, results)
+	_send_response(id, results)
+
+
+const _MAX_FIND_RESULTS := 1000
+
+func _find_nodes_recursive(node: Node, type_filter: String, name_pattern: String, group_filter: String, results: Array) -> void:
+	if results.size() >= _MAX_FIND_RESULTS:
+		return
+
+	var matches := true
+
+	if not type_filter.is_empty() and not node.is_class(type_filter):
+		matches = false
+	if not name_pattern.is_empty() and not String(node.name).match(name_pattern):
+		matches = false
+	if not group_filter.is_empty() and not node.is_in_group(group_filter):
+		matches = false
+
+	if matches:
+		results.append({
+			"name": node.name,
+			"type": node.get_class(),
+			"path": str(node.get_path())
+		})
+
+	for child in node.get_children():
+		_find_nodes_recursive(child, type_filter, name_pattern, group_filter, results)
+
+
+func _handle_get_viewport_info(id, _params: Dictionary) -> void:
+	var vp := get_viewport()
+	var result := {
+		"size": _variant_to_json(vp.get_visible_rect().size),
+		"mouse_position": _variant_to_json(vp.get_mouse_position()),
+	}
+
+	# Try to find active Camera2D
+	var camera_2d := vp.get_camera_2d()
+	if camera_2d:
+		result["camera_2d"] = {
+			"position": _variant_to_json(camera_2d.global_position),
+			"zoom": _variant_to_json(camera_2d.zoom),
+		}
+
+	# Try to find active Camera3D
+	var camera_3d := vp.get_camera_3d()
+	if camera_3d:
+		result["camera_3d"] = {
+			"position": _variant_to_json(camera_3d.global_position),
+			"fov": camera_3d.fov,
+		}
+
+	_send_response(id, result)
+
+
+# --- Handlers: Game State Queries ---
+
+## Methods blocked from call_method unless --unsafe is set.
+const _BLOCKED_METHODS := [
+	"queue_free", "free", "set_script", "remove_child",
+	"call", "callv", "call_deferred", "emit_signal",
+]
+
+func _handle_call_method(id, params: Dictionary) -> void:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		_send_error(id, -32602, "Missing required parameter: node_path")
+		return
+
+	var method_name: String = params.get("method_name", "")
+	if method_name.is_empty():
+		_send_error(id, -32602, "Missing required parameter: method_name")
+		return
+
+	# Block dangerous methods unless --unsafe
+	if not _unsafe_mode and method_name in _BLOCKED_METHODS:
+		_send_error(id, -32001, "Method '%s' is blocked without --unsafe flag" % method_name)
+		return
+
+	var node := get_node_or_null(node_path)
+	if node == null:
+		_send_error(id, -32602, "Node not found: %s" % node_path)
+		return
+
+	var method_args: Array = params.get("args", [])
+
+	var result = node.callv(method_name, method_args)
+	_send_response(id, _variant_to_json(result))
+
+
+func _handle_get_singleton(id, params: Dictionary) -> void:
+	var singleton_name: String = params.get("singleton_name", "")
+	if singleton_name.is_empty():
+		_send_error(id, -32602, "Missing required parameter: singleton_name")
+		return
+
+	# Reject path traversal
+	if ".." in singleton_name or "/" in singleton_name:
+		_send_error(id, -32602, "Invalid singleton name: must be a simple name, not a path")
+		return
+
+	var node := get_node_or_null("/root/" + singleton_name)
+	if node == null:
+		_send_error(id, -32602, "Singleton not found: %s" % singleton_name)
+		return
+
+	var properties: Array = params.get("properties", [])
+	var result := {}
+	for prop_name in properties:
+		result[prop_name] = _variant_to_json(node.get(prop_name))
+
+	_send_response(id, result)
+
+
+func _handle_evaluate_expression(id, params: Dictionary) -> void:
+	if not _unsafe_mode:
+		_send_error(id, -32001, "evaluate_expression requires --unsafe flag on TestBridge")
+		return
+
+	var expr_string: String = params.get("expression", "")
+	if expr_string.is_empty():
+		_send_error(id, -32602, "Missing required parameter: expression")
+		return
+
+	var base_path: String = params.get("base_node_path", "/root")
+	var base_node := get_node_or_null(base_path)
+	if base_node == null:
+		_send_error(id, -32602, "Base node not found: %s" % base_path)
+		return
+
+	var expr := Expression.new()
+	var parse_err := expr.parse(expr_string)
+	if parse_err != OK:
+		_send_error(id, -32602, "Expression parse error: %s" % expr.get_error_text())
+		return
+
+	var result = expr.execute([], base_node)
+	if expr.has_execute_failed():
+		_send_error(id, -32603, "Expression execution failed: %s" % expr.get_error_text())
+		return
+
+	_send_response(id, _variant_to_json(result))
+
+
+# --- Handlers: Wait / Polling ---
+
+func _handle_wait_for_condition(id, params: Dictionary) -> void:
+	if not _unsafe_mode:
+		_send_error(id, -32001, "wait_for_condition uses expression evaluation and requires --unsafe flag")
+		return
+
+	var expr_string: String = params.get("expression", "")
+	if expr_string.is_empty():
+		_send_error(id, -32602, "Missing required parameter: expression")
+		return
+
+	var timeout_ms: int = int(params.get("timeout_ms", 5000))
+	var poll_interval_ms: int = max(16, int(params.get("poll_interval_ms", 100)))
+	var base_path: String = params.get("base_node_path", "/root")
+
+	var base_node := get_node_or_null(base_path)
+	if base_node == null:
+		_send_error(id, -32602, "Base node not found: %s" % base_path)
+		return
+
+	# Pre-validate expression
+	var expr := Expression.new()
+	var parse_err := expr.parse(expr_string)
+	if parse_err != OK:
+		_send_error(id, -32602, "Expression parse error: %s" % expr.get_error_text())
+		return
+
+	# Mark as async and start coroutine
+	_pending_responses[str(id)] = true
+	_poll_condition(id, expr_string, base_node, timeout_ms, poll_interval_ms)
+
+
+func _poll_condition(id, expr_string: String, base_node: Node, timeout_ms: int, poll_interval_ms: int) -> void:
+	var start_time := Time.get_ticks_msec()
+	var interval_sec := poll_interval_ms / 1000.0
+	var last_value = null
+
+	while true:
+		var elapsed := Time.get_ticks_msec() - start_time
+		if elapsed >= timeout_ms:
+			_send_response(id, {"satisfied": false, "timeout": true, "last_value": _variant_to_json(last_value), "elapsed_ms": elapsed})
+			return
+
+		# Guard against dangling node reference after scene change
+		if not is_instance_valid(base_node):
+			_send_error(id, -32603, "Base node was freed (scene changed during wait)")
+			return
+
+		var expr := Expression.new()
+		var parse_err := expr.parse(expr_string)
+		if parse_err != OK:
+			_send_error(id, -32603, "Expression error during polling: %s" % expr.get_error_text())
+			return
+
+		var result = expr.execute([], base_node)
+		if expr.has_execute_failed():
+			_send_error(id, -32603, "Expression execution failed: %s" % expr.get_error_text())
+			return
+
+		last_value = result
+		if result:  # Truthy check
+			_send_response(id, {"satisfied": true, "value": _variant_to_json(result), "elapsed_ms": int(Time.get_ticks_msec() - start_time)})
+			return
+
+		await get_tree().create_timer(interval_sec).timeout
+
+
+func _handle_wait_frames(id, params: Dictionary) -> void:
+	var count: int = int(params.get("count", 1))
+	if count < 1:
+		_send_error(id, -32602, "count must be >= 1")
+		return
+
+	_pending_responses[str(id)] = true
+	_do_wait_frames(id, count)
+
+
+func _do_wait_frames(id, count: int) -> void:
+	for i in range(count):
+		await get_tree().process_frame
+	_send_response(id, {"frames_waited": count})
+
+
+func _handle_wait_for_signal(id, params: Dictionary) -> void:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		_send_error(id, -32602, "Missing required parameter: node_path")
+		return
+
+	var signal_name: String = params.get("signal_name", "")
+	if signal_name.is_empty():
+		_send_error(id, -32602, "Missing required parameter: signal_name")
+		return
+
+	var timeout_ms: int = int(params.get("timeout_ms", 5000))
+
+	var node := get_node_or_null(node_path)
+	if node == null:
+		_send_error(id, -32602, "Node not found: %s" % node_path)
+		return
+
+	if not node.has_signal(signal_name):
+		_send_error(id, -32602, "Signal not found: %s on node %s" % [signal_name, node_path])
+		return
+
+	_pending_responses[str(id)] = true
+	_do_wait_for_signal(id, node, signal_name, timeout_ms)
+
+
+func _do_wait_for_signal(id, node: Node, signal_name: String, timeout_ms: int) -> void:
+	var received := false
+	var signal_args := []
+
+	# One-shot signal connection — capture args via variadic lambda
+	var callable := func(a1 = null, a2 = null, a3 = null, a4 = null):
+		received = true
+		for arg in [a1, a2, a3, a4]:
+			if arg != null:
+				signal_args.append(_variant_to_json(arg))
+	node.connect(signal_name, callable, CONNECT_ONE_SHOT)
+
+	# Wait with timeout
+	var start_time := Time.get_ticks_msec()
+	while not received:
+		# Guard against dangling node reference after scene change
+		if not is_instance_valid(node):
+			_send_error(id, -32603, "Node was freed (scene changed during wait)")
+			return
+		var elapsed := Time.get_ticks_msec() - start_time
+		if elapsed >= timeout_ms:
+			# Disconnect if still connected
+			if is_instance_valid(node) and node.is_connected(signal_name, callable):
+				node.disconnect(signal_name, callable)
+			_send_response(id, {"received": false, "timeout": true, "elapsed_ms": elapsed})
+			return
+		await get_tree().create_timer(0.016).timeout
+
+	_send_response(id, {"received": true, "args": signal_args, "elapsed_ms": int(Time.get_ticks_msec() - start_time)})
+
+
+# --- Handlers: Visual Verification ---
+
+func _handle_take_screenshot(id, params: Dictionary) -> void:
+	if DisplayServer.get_name() == "headless":
+		_send_error(id, -32002, "Visual tools require a display. Game is running in headless mode.")
+		return
+
+	_pending_responses[str(id)] = true
+	_do_take_screenshot(id, params)
+
+
+func _do_take_screenshot(id, params: Dictionary) -> void:
+	await RenderingServer.frame_post_draw
+
+	var texture := get_viewport().get_texture()
+	if texture == null:
+		_send_error(id, -32603, "No viewport texture available — scene may be loading")
+		return
+
+	var image := texture.get_image()
+	if image == null:
+		_send_error(id, -32603, "Failed to get image from viewport texture")
+		return
+
+	# Optional region crop
+	var region = params.get("region", null)
+	if region != null and typeof(region) == TYPE_DICTIONARY:
+		var rx: int = int(region.get("x", 0))
+		var ry: int = int(region.get("y", 0))
+		var rw: int = int(region.get("width", image.get_width()))
+		var rh: int = int(region.get("height", image.get_height()))
+		image = image.get_region(Rect2i(rx, ry, rw, rh))
+
+	var buffer := image.save_png_to_buffer()
+	var base64 := Marshalls.raw_to_base64(buffer)
+
+	_send_response(id, {
+		"format": "png",
+		"width": image.get_width(),
+		"height": image.get_height(),
+		"data": base64
+	})
+
+
+func _handle_get_pixel_color(id, params: Dictionary) -> void:
+	if DisplayServer.get_name() == "headless":
+		_send_error(id, -32002, "Visual tools require a display. Game is running in headless mode.")
+		return
+
+	if not params.has("x") or not params.has("y"):
+		_send_error(id, -32602, "Missing required parameters: x, y")
+		return
+
+	_pending_responses[str(id)] = true
+	_do_get_pixel_color(id, int(params.x), int(params.y))
+
+
+func _do_get_pixel_color(id, x: int, y: int) -> void:
+	await RenderingServer.frame_post_draw
+
+	var texture := get_viewport().get_texture()
+	if texture == null:
+		_send_error(id, -32603, "No viewport texture available")
+		return
+
+	var image := texture.get_image()
+	if image == null:
+		_send_error(id, -32603, "Failed to get image from viewport texture")
+		return
+
+	if x < 0 or x >= image.get_width() or y < 0 or y >= image.get_height():
+		_send_error(id, -32602, "Coordinates (%d, %d) out of bounds (image: %dx%d)" % [x, y, image.get_width(), image.get_height()])
+		return
+
+	var color := image.get_pixel(x, y)
+	_send_response(id, {"r": color.r, "g": color.g, "b": color.b, "a": color.a})
+
+
+# --- Handlers: Test Orchestration ---
+
+func _handle_reset_scene(id, _params: Dictionary) -> void:
+	_pending_responses[str(id)] = true
+	get_tree().reload_current_scene()
+	await get_tree().process_frame
+	var current := get_tree().current_scene
+	if current:
+		_send_response(id, {"scene": current.scene_file_path})
+	else:
+		_send_error(id, -32603, "Scene reload completed but current_scene is null")
+
+
+func _handle_load_scene(id, params: Dictionary) -> void:
+	var scene_path: String = params.get("scene_path", "")
+	if scene_path.is_empty():
+		_send_error(id, -32602, "Missing required parameter: scene_path")
+		return
+
+	_pending_responses[str(id)] = true
+	var err := get_tree().change_scene_to_file(scene_path)
+	if err != OK:
+		_send_error(id, -32603, "Failed to load scene: %s (error %d)" % [scene_path, err])
+		return
+	await get_tree().process_frame
+	_send_response(id, {"scene": scene_path})
+
+
+# --- Variant Serialization ---
+
+func _variant_to_json(value):
+	if value == null:
+		return null
+
+	match typeof(value):
+		TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
+			return value
+		TYPE_VECTOR2:
+			return {"x": value.x, "y": value.y}
+		TYPE_VECTOR3:
+			return {"x": value.x, "y": value.y, "z": value.z}
+		TYPE_COLOR:
+			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+		TYPE_RECT2:
+			return {"position": {"x": value.position.x, "y": value.position.y}, "size": {"x": value.size.x, "y": value.size.y}}
+		TYPE_TRANSFORM2D:
+			return {"origin": {"x": value.origin.x, "y": value.origin.y}, "x": {"x": value.x.x, "y": value.x.y}, "y": {"x": value.y.x, "y": value.y.y}}
+		TYPE_NODE_PATH:
+			return str(value)
+		TYPE_RID:
+			return str(value)
+		TYPE_OBJECT:
+			if value == null:
+				return null
+			var result := {"_class": value.get_class()}
+			if value is Node:
+				result["_path"] = str(value.get_path())
+			return result
+		TYPE_ARRAY:
+			var arr := []
+			for item in value:
+				arr.append(_variant_to_json(item))
+			return arr
+		TYPE_DICTIONARY:
+			var dict := {}
+			for key in value:
+				dict[str(key)] = _variant_to_json(value[key])
+			return dict
+		_:
+			return {"_type": type_string(typeof(value)), "_string": str(value)}
+
+
+# --- C# Interop ---
+
+func _is_csharp_node(node: Node) -> bool:
+	var script = node.get_script()
+	if script == null:
+		return false
+	return script is CSharpScript if ClassDB.class_exists("CSharpScript") else false
+
+
+func _to_pascal_case(snake: String) -> String:
+	var parts := snake.split("_")
+	var result := ""
+	for part in parts:
+		if not part.is_empty():
+			result += part[0].to_upper() + part.substr(1)
+	return result
+
+
+# --- Avalonia Support ---
+
+func _find_avalonia_nodes() -> Array:
+	var results := []
+	if get_tree() and get_tree().root:
+		_find_avalonia_recursive(get_tree().root, results)
+	return results
+
+
+func _find_avalonia_recursive(node: Node, results: Array) -> void:
+	var class_name_str := node.get_class()
+	if "AvaloniaControl" in class_name_str or "Estragonia" in class_name_str:
+		results.append(node)
+	for child in node.get_children():
+		_find_avalonia_recursive(child, results)
+
+
+func _try_avalonia_input(pos: Vector2, event: InputEvent) -> void:
+	var avalonia_nodes := _find_avalonia_nodes()
+	for av_node in avalonia_nodes:
+		if av_node is Control:
+			var rect: Rect2 = av_node.get_global_rect()
+			if rect.has_point(pos):
+				var local_pos := pos - rect.position
+				# Attempt to forward input — graceful degradation if method not found
+				if av_node.has_method("_gui_input"):
+					av_node.call("_gui_input", event)
+				elif av_node.has_method("_input_event"):
+					av_node.call("_input_event", event)
+				else:
+					printerr("[TestBridge] AvaloniaControl found but no input forwarding method available — falling back to standard input only")
+				break
+
+
+# --- Key Map ---
+
+func _build_key_map() -> void:
+	_key_map = {
+		"Space": KEY_SPACE,
+		"Enter": KEY_ENTER,
+		"Escape": KEY_ESCAPE,
+		"Tab": KEY_TAB,
+		"Backspace": KEY_BACKSPACE,
+		"Delete": KEY_DELETE,
+		"Up": KEY_UP,
+		"Down": KEY_DOWN,
+		"Left": KEY_LEFT,
+		"Right": KEY_RIGHT,
+		"Home": KEY_HOME,
+		"End": KEY_END,
+		"PageUp": KEY_PAGEUP,
+		"PageDown": KEY_PAGEDOWN,
+		"Insert": KEY_INSERT,
+		"F1": KEY_F1,
+		"F2": KEY_F2,
+		"F3": KEY_F3,
+		"F4": KEY_F4,
+		"F5": KEY_F5,
+		"F6": KEY_F6,
+		"F7": KEY_F7,
+		"F8": KEY_F8,
+		"F9": KEY_F9,
+		"F10": KEY_F10,
+		"F11": KEY_F11,
+		"F12": KEY_F12,
+	}
+
+
+# --- Logging ---
+
+func _log_debug(msg: String) -> void:
+	if _debug:
+		printerr("[TestBridge] %s" % msg)

--- a/test/fixtures/test-project/addons/test_bridge/TestBridge.gd
+++ b/test/fixtures/test-project/addons/test_bridge/TestBridge.gd
@@ -1,0 +1,1 @@
+../../../../src/scripts/test_bridge.gd

--- a/test/fixtures/test-project/main.gd
+++ b/test/fixtures/test-project/main.gd
@@ -1,0 +1,11 @@
+extends Node2D
+
+signal test_signal
+
+func _ready() -> void:
+	# Emit test_signal after 1 second for wait_for_signal testing
+	get_tree().create_timer(1.0).timeout.connect(func(): test_signal.emit())
+
+
+func get_test_value() -> int:
+	return 42

--- a/test/fixtures/test-project/main.tscn
+++ b/test/fixtures/test-project/main.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://main.gd" id="1"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1")
+
+[node name="TestLabel" type="Label" parent="."]
+text = "Hello Test"

--- a/test/fixtures/test-project/project.godot
+++ b/test/fixtures/test-project/project.godot
@@ -1,0 +1,17 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] key=value
+
+config_version=5
+
+[application]
+
+config/name="TestProject"
+run/main_scene="res://main.tscn"
+
+[autoload]
+
+TestBridge="*res://addons/test_bridge/TestBridge.gd"


### PR DESCRIPTION
## Summary

- Adds a WebSocket-based E2E testing bridge that connects the MCP server to **running** Godot games for live testing
- Implements 25 new MCP tools across 7 categories: connection management, scene tree inspection, game state queries, input simulation, wait/polling, visual verification, and test orchestration
- Includes TestBridge.gd autoload for Godot that runs a WebSocket server inside the game, processing JSON-RPC commands in the game's `_process()` loop

### New files
- `src/bridge.ts` — WebSocket client + JSON-RPC transport
- `src/e2e-tools.ts` — 25 tool schemas and handlers
- `src/scripts/test_bridge.gd` — Godot autoload WebSocket server
- `test/fixtures/test-project/` — Test fixture project

### Modified files
- `src/index.ts` — Wires BridgeClient and E2E tools into GodotServer
- `package.json` — Adds `ws` dependency
- `scripts/build.js` — Copies test_bridge.gd to build output
- `CLAUDE.md` / `README.md` — Updated documentation

### Safety model
- `evaluate_expression`, `wait_for_condition`, and dangerous methods in `call_method` require `--unsafe` flag
- Singleton names reject path traversal (`..`, `/`)
- `find_nodes` results capped at 1000
- All path inputs validated against `..` traversal

### Tool categories

| Category | Tools |
|---|---|
| Connection | `connect_to_game`, `disconnect_from_game`, `get_bridge_status` |
| Orchestration | `install_test_bridge`, `run_project_with_bridge` |
| Scene Tree | `get_tree`, `find_nodes`, `get_node_properties`, `set_node_property`, `call_method` |
| Game State | `get_singleton`, `evaluate_expression`, `get_performance_metrics` |
| Input | `send_key`, `send_mouse_click`, `send_mouse_drag`, `send_text` |
| Waiting | `wait_for_signal`, `wait_for_condition`, `wait_for_node`, `wait_for_property` |
| Visual | `take_screenshot`, `get_viewport_info` |
| Scene Control | `reset_scene`, `load_scene` |

## Test plan

- [ ] `npm run build` compiles without errors
- [ ] `npm run inspector` launches and shows all 40 tools
- [ ] `install_test_bridge` registers autoload in project.godot
- [ ] `run_project_with_bridge` launches game and auto-connects
- [ ] Scene tree tools return correct node data from a running game
- [ ] Input simulation tools produce visible effects in-game
- [ ] Wait tools resolve when conditions are met and timeout correctly
- [ ] `take_screenshot` returns valid base64 PNG
- [ ] Safety-gated tools reject without `--unsafe` flag
- [ ] Disconnecting cleans up all resources