### PR TITLE
fix: load resource paths when setting node properties in add_node

### DIFF
--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -528,7 +528,12 @@ func add_node(params):
         for property in properties:
             if debug_mode:
                 print("Setting property: " + property + " = " + str(properties[property]))
-            new_node.set(property, properties[property])
+            var value = properties[property]
+            if typeof(value) == TYPE_STRING and value.begins_with("res://"):
+                value = load(value)
+                if debug_mode:
+                    print("Loaded resource for property: " + property + " -> " + str(value))
+            new_node.set(property, value)
     
     parent.add_child(new_node)
     new_node.owner = scene_root


### PR DESCRIPTION
## Summary

- `add_node` properties with string values starting with `res://` are now automatically loaded as Godot resources before being passed to `Node.set()`
- This fixes script attachment via the `properties` parameter (e.g. `{"script": "res://my_script.gd"}`) — previously the raw string was passed, which silently failed since `Node.set("script", ...)` requires an actual `Script` object
- Other resource types (textures, materials, etc.) benefit from the same fix

## Test plan

- [ ] Call `add_node` with `"properties": {"script": "res://path/to/script.gd"}` and verify the script is saved as an `ext_resource` reference in the `.tscn` file
- [ ] Verify non-`res://` string properties are still set as plain strings
- [ ] Verify the node runs the attached script correctly when the scene is played

🤖 Generated with [Claude Code](https://claude.com/claude-code)