### PR TITLE
docs: restructure README with Claude Code as primary setup, npx install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Godot MCP
 
 [![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/Coding-Solo)
@@ -13,53 +12,52 @@
 [![](https://img.shields.io/github/forks/Coding-Solo/godot-mcp 'Forks')](https://github.com/Coding-Solo/godot-mcp/network/members)
 [![](https://img.shields.io/badge/License-MIT-red.svg 'MIT License')](https://opensource.org/licenses/MIT)
 
-```text
-                           (((((((             (((((((                          
-                        (((((((((((           (((((((((((                      
-                        (((((((((((((       (((((((((((((                       
-                        (((((((((((((((((((((((((((((((((                       
-                        (((((((((((((((((((((((((((((((((                       
-         (((((      (((((((((((((((((((((((((((((((((((((((((      (((((        
-       (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((      
-     ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((    
-    ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((    
-      (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((     
-        (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((       
-         (((((((((((@@@@@@@(((((((((((((((((((((((((((@@@@@@@(((((((((((        
-         (((((((((@@@@,,,,,@@@(((((((((((((((((((((@@@,,,,,@@@@(((((((((        
-         ((((((((@@@,,,,,,,,,@@(((((((@@@@@(((((((@@,,,,,,,,,@@@((((((((        
-         ((((((((@@@,,,,,,,,,@@(((((((@@@@@(((((((@@,,,,,,,,,@@@((((((((        
-         (((((((((@@@,,,,,,,@@((((((((@@@@@((((((((@@,,,,,,,@@@(((((((((        
-         ((((((((((((@@@@@@(((((((((((@@@@@(((((((((((@@@@@@((((((((((((        
-         (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((        
-         (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((        
-         @@@@@@@@@@@@@((((((((((((@@@@@@@@@@@@@((((((((((((@@@@@@@@@@@@@        
-         ((((((((( @@@(((((((((((@@(((((((((((@@(((((((((((@@@ (((((((((        
-         (((((((((( @@((((((((((@@@(((((((((((@@@((((((((((@@ ((((((((((        
-          (((((((((((@@@@@@@@@@@@@@(((((((((((@@@@@@@@@@@@@@(((((((((((         
-           (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((          
-              (((((((((((((((((((((((((((((((((((((((((((((((((((((             
-                 (((((((((((((((((((((((((((((((((((((((((((((((                
-                        (((((((((((((((((((((((((((((((((                       
-                                                                                
 
-                          /$$      /$$  /$$$$$$  /$$$$$$$ 
+```text
+                           (((((((             (((((((
+                        (((((((((((           (((((((((((
+                        (((((((((((((       (((((((((((((
+                        (((((((((((((((((((((((((((((((((
+                        (((((((((((((((((((((((((((((((((
+         (((((      (((((((((((((((((((((((((((((((((((((((((      (((((
+       (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+     ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+    ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+      (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+         (((((((((((@@@@@@@(((((((((((((((((((((((((((@@@@@@@(((((((((((
+         (((((((((@@@@,,,,,@@@(((((((((((((((((((((@@@,,,,,@@@@(((((((((
+         ((((((((@@@,,,,,,,,,@@(((((((@@@@@(((((((@@,,,,,,,,,@@@((((((((
+         ((((((((@@@,,,,,,,,,@@(((((((@@@@@(((((((@@,,,,,,,,,@@@((((((((
+         (((((((((@@@,,,,,,,@@((((((((@@@@@((((((((@@,,,,,,,@@@(((((((((
+         ((((((((((((@@@@@@(((((((((((@@@@@(((((((((((@@@@@@((((((((((((
+         (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+         (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+         @@@@@@@@@@@@@((((((((((((@@@@@@@@@@@@@((((((((((((@@@@@@@@@@@@@
+         ((((((((( @@@(((((((((((@@(((((((((((@@(((((((((((@@@ (((((((((
+         (((((((((( @@((((((((((@@@(((((((((((@@@((((((((((@@ ((((((((((
+          (((((((((((@@@@@@@@@@@@@@(((((((((((@@@@@@@@@@@@@@(((((((((((
+           (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+              (((((((((((((((((((((((((((((((((((((((((((((((((((((
+                 (((((((((((((((((((((((((((((((((((((((((((((((
+                        (((((((((((((((((((((((((((((((((
+
+
+                          /$$      /$$  /$$$$$$  /$$$$$$$
                          | $$$    /$$$ /$$__  $$| $$__  $$
                          | $$$$  /$$$$| $$  \__/| $$  \ $$
                          | $$ $$/$$ $$| $$      | $$$$$$$/
-                         | $$  $$$| $$| $$      | $$____/ 
-                         | $$\  $ | $$| $$    $$| $$      
-                         | $$ \/  | $$|  $$$$$$/| $$      
-                         |__/     |__/ \______/ |__/       
+                         | $$  $$$| $$| $$      | $$____/
+                         | $$\  $ | $$| $$    $$| $$
+                         | $$ \/  | $$|  $$$$$$/| $$
+                         |__/     |__/ \______/ |__/
 ```
 
 A Model Context Protocol (MCP) server for interacting with the Godot game engine.
 
 ## Introduction
 
-Godot MCP enables AI assistants to launch the Godot editor, run projects, capture debug output, and control project execution - all through a standardized interface.
-
-This direct feedback loop helps AI assistants like Claude understand what works and what doesn't in real Godot projects, leading to better code generation and debugging assistance.
+Godot MCP enables AI agents to launch the Godot editor, run projects, capture debug output, and control project execution. This direct feedback loop helps agents understand what works and what doesn't in real Godot projects, leading to better code generation and debugging assistance.
 
 ## Features
 
@@ -83,25 +81,27 @@ This direct feedback loop helps AI assistants like Claude understand what works 
 ## Requirements
 
 - [Godot Engine](https://godotengine.org/download) installed on your system
-- Node.js and npm
-- An AI assistant that supports MCP (Cline, Cursor, etc.)
+- Node.js (>=18.0.0) and npm
+- An AI agent that supports MCP
 
-## Installation and Configuration
+## Quick Start
 
-### Step 1: Install and Build
-
-First, clone the repository and build the MCP server:
+### Claude Code
 
 ```bash
-git clone https://github.com/Coding-Solo/godot-mcp.git
-cd godot-mcp
-npm install
-npm run build
+claude mcp add godot -- npx @coding-solo/godot-mcp
 ```
 
-### Step 2: Configure with Your AI Assistant
+That's it. Restart Claude Code and your Godot MCP tools are available.
 
-#### Option A: Configure with Cline
+With environment variables:
+
+```bash
+claude mcp add godot -e GODOT_PATH=/path/to/godot -e DEBUG=true -- npx @coding-solo/godot-mcp
+```
+
+<details>
+<summary><strong>Cline</strong></summary>
 
 Add to your Cline MCP settings file (`~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`):
 
@@ -109,10 +109,10 @@ Add to your Cline MCP settings file (`~/Library/Application Support/Code/User/gl
 {
   "mcpServers": {
     "godot": {
-      "command": "node",
-      "args": ["/absolute/path/to/godot-mcp/build/index.js"],
+      "command": "npx",
+      "args": ["@coding-solo/godot-mcp"],
       "env": {
-        "DEBUG": "true"                  // Optional: Enable detailed logging
+        "DEBUG": "true"
       },
       "disabled": false,
       "autoApprove": [
@@ -136,106 +136,111 @@ Add to your Cline MCP settings file (`~/Library/Application Support/Code/User/gl
 }
 ```
 
-#### Option B: Configure with Cursor
+</details>
+
+<details>
+<summary><strong>Cursor</strong></summary>
 
 **Using the Cursor UI:**
 
 1. Go to **Cursor Settings** > **Features** > **MCP**
 2. Click on the **+ Add New MCP Server** button
 3. Fill out the form:
-   - Name: `godot` (or any name you prefer)
+   - Name: `godot`
    - Type: `command`
-   - Command: `node /absolute/path/to/godot-mcp/build/index.js`
+   - Command: `npx @coding-solo/godot-mcp`
 4. Click "Add"
 5. You may need to press the refresh button in the top right corner of the MCP server card to populate the tool list
 
 **Using Project-Specific Configuration:**
 
-Create a file at `.cursor/mcp.json` in your project directory with the following content:
+Create a file at `.cursor/mcp.json` in your project directory:
 
 ```json
 {
   "mcpServers": {
     "godot": {
-      "command": "node",
-      "args": ["/absolute/path/to/godot-mcp/build/index.js"],
+      "command": "npx",
+      "args": ["@coding-solo/godot-mcp"],
       "env": {
-        "DEBUG": "true"                  // Enable detailed logging
+        "DEBUG": "true"
       }
     }
   }
 }
 ```
 
-### Step 3: Optional Environment Variables
+</details>
 
-You can customize the server behavior with these environment variables:
+<details>
+<summary><strong>Other MCP Clients</strong></summary>
 
-- `GODOT_PATH`: Path to the Godot executable (overrides automatic detection)
-- `DEBUG`: Set to "true" to enable detailed server-side debug logging
+For any MCP-compatible client, use this configuration:
 
-## Example Prompts
-
-Once configured, your AI assistant will automatically run the MCP server when needed. You can use prompts like:
-
-```text
-"Launch the Godot editor for my project at /path/to/project"
-
-"Run my Godot project and show me any errors"
-
-"Get information about my Godot project structure"
-
-"Analyze my Godot project structure and suggest improvements"
-
-"Help me debug this error in my Godot project: [paste error]"
-
-"Write a GDScript for a character controller with double jump and wall sliding"
-
-"Create a new scene with a Player node in my Godot project"
-
-"Add a Sprite2D node to my player scene and load the character texture"
-
-"Export my 3D models as a MeshLibrary for use with GridMap"
-
-"Create a UI scene with buttons and labels for my game's main menu"
-
-"Get the UID for a specific script file in my Godot 4.4 project"
-
-"Update UID references in my Godot project after upgrading to 4.4"
+```json
+{
+  "mcpServers": {
+    "godot": {
+      "command": "npx",
+      "args": ["@coding-solo/godot-mcp"],
+      "env": {
+        "GODOT_PATH": "/path/to/godot",
+        "DEBUG": "true"
+      }
+    }
+  }
+}
 ```
 
-## Implementation Details
+</details>
 
-### Architecture
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `GODOT_PATH` | Path to the Godot executable (overrides automatic detection) |
+| `DEBUG` | Set to `"true"` to enable detailed server-side debug logging |
+
+<details>
+<summary><strong>Building from Source</strong></summary>
+
+```bash
+git clone https://github.com/Coding-Solo/godot-mcp.git
+cd godot-mcp
+npm install
+npm run build
+```
+
+Then point your MCP client to `build/index.js` instead of using `npx`.
+
+</details>
+
+
+## Architecture
 
 The Godot MCP server uses a bundled GDScript approach for complex operations:
 
 1. **Direct Commands**: Simple operations like launching the editor or getting project info use Godot's built-in CLI commands directly.
 2. **Bundled Operations Script**: Complex operations like creating scenes or adding nodes use a single, comprehensive GDScript file (`godot_operations.gd`) that handles all operations.
 
-This architecture provides several benefits:
-
-- **No Temporary Files**: Eliminates the need for temporary script files, keeping your system clean
-- **Simplified Codebase**: Centralizes all Godot operations in one (somewhat) organized file
-- **Better Maintainability**: Makes it easier to add new operations or modify existing ones
-- **Improved Error Handling**: Provides consistent error reporting across all operations
-- **Reduced Overhead**: Minimizes file I/O operations for better performance
-
 The bundled script accepts operation type and parameters as JSON, allowing for flexible and dynamic operation execution without generating temporary files for each operation.
 
 ## Troubleshooting
 
-- **Godot Not Found**: Set the GODOT_PATH environment variable to your Godot executable
+- **Godot Not Found**: Set the `GODOT_PATH` environment variable to your Godot executable path
 - **Connection Issues**: Ensure the server is running and restart your AI assistant
-- **Invalid Project Path**: Ensure the path points to a directory containing a project.godot file
+- **Invalid Project Path**: Ensure the path points to a directory containing a `project.godot` file
 - **Build Issues**: Make sure all dependencies are installed by running `npm install`
-- **For Cursor Specifically**:
--   Ensure the MCP server shows up and is enabled in Cursor settings (Settings > MCP)
--   MCP tools can only be run using the Agent chat profile (Cursor Pro or Business subscription)
--   Use "Yolo Mode" to automatically run MCP tool requests
+
+<details>
+<summary><strong>Cursor-Specific Issues</strong></summary>
+
+- Ensure the MCP server shows up and is enabled in Cursor settings (Settings > MCP)
+- MCP tools can only be run using the Agent chat profile (Cursor Pro or Business subscription)
+- Use "Yolo Mode" to automatically run MCP tool requests
+
+</details>
 
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/coding-solo-godot-mcp-badge.png)](https://mseep.ai/app/coding-solo-godot-mcp)


### PR DESCRIPTION
- Make Claude Code the recommended/default setup path (one command)
- Switch all install instructions from clone+build to npx @coding-solo/godot-mcp
- Collapse Cline, Cursor, and other client configs into dropdowns
- Move building from source into a dropdown for contributors
- Consolidate introduction into a single paragraph
- Remove example prompts section
- Format env vars as a table
- Simplify architecture section