### PR TITLE
fix: prevent arbitrary GDScript instantiation via add_node/create_scene

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,16 @@ class GodotServer {
   }
 
   /**
+   * Validate a Godot class name to prevent arbitrary script instantiation.
+   * Class names must be simple identifiers (e.g. "Node2D", "CharacterBody3D").
+   * Rejects anything that looks like a path (res://, absolute paths, dots, slashes, colons).
+   */
+  private validateClassName(name: string): boolean {
+    if (!name) return false;
+    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+  }
+
+  /**
    * Synchronous validation for constructor use
    * This is a quick check that only verifies file existence, not executable validity
    * Full validation will be performed later in detectGodotPath
@@ -1487,6 +1497,14 @@ class GodotServer {
       );
     }
 
+    const rootNodeType = args.rootNodeType || 'Node2D';
+    if (!this.validateClassName(rootNodeType)) {
+      return this.createErrorResponse(
+        'Invalid rootNodeType',
+        ['rootNodeType must be a built-in Godot class name (no paths, no file extensions)']
+      );
+    }
+
     try {
       // Check if the project directory exists and contains a project.godot file
       const projectFile = join(args.projectPath, 'project.godot');
@@ -1503,7 +1521,7 @@ class GodotServer {
       // Prepare parameters for the operation (already in camelCase)
       const params = {
         scenePath: args.scenePath,
-        rootNodeType: args.rootNodeType || 'Node2D',
+        rootNodeType,
       };
 
       // Execute the operation
@@ -1558,6 +1576,13 @@ class GodotServer {
       return this.createErrorResponse(
         'Invalid path',
         ['Provide valid paths without ".." or other potentially unsafe characters']
+      );
+    }
+
+    if (!this.validateClassName(args.nodeType)) {
+      return this.createErrorResponse(
+        'Invalid nodeType',
+        ['nodeType must be a built-in Godot class name (no paths, no file extensions)']
       );
     }
 

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -88,25 +88,14 @@ func log_info(message):
 func log_error(message):
     printerr("[ERROR] " + message)
 
-# Get a script by name or path
+# Get a script by registered class name.
+# Only looks up names via the project's global class registry. Raw paths
+# (e.g. "res://evil.gd") are intentionally not accepted here to prevent
+# arbitrary script instantiation from agent-supplied input.
 func get_script_by_name(name_of_class):
     if debug_mode:
         print("Attempting to get script for class: " + name_of_class)
-    
-    # Try to load it directly if it's a resource path
-    if ResourceLoader.exists(name_of_class, "Script"):
-        if debug_mode:
-            print("Resource exists, loading directly: " + name_of_class)
-        var script = load(name_of_class) as Script
-        if script:
-            if debug_mode:
-                print("Successfully loaded script from path")
-            return script
-        else:
-            printerr("Failed to load script from path: " + name_of_class)
-    elif debug_mode:
-        print("Resource not found, checking global class registry")
-    
+
     # Search for it in the global class registry if it's a class name
     var global_classes = ProjectSettings.get_global_class_list()
     if debug_mode:


### PR DESCRIPTION
The add_node and create_scene tools accept a class name parameter (nodeType, rootNodeType) which is passed to godot_operations.gd. The GDScript helper get_script_by_name previously fell back to ResourceLoader.exists / load() on the raw name, meaning a value like "res://evil.gd" would load and instantiate an arbitrary script, running its _init() in the Godot process.

Fix in two layers:

- TypeScript: validate nodeType and rootNodeType as simple identifiers (^[A-Za-z_][A-Za-z0-9_]*$) in handleAddNode and handleCreateScene. Rejects anything containing /, ., :, or res:// prefixes.

- GDScript: remove the load(name_of_class) fallback from get_script_by_name. Lookups now only go through ProjectSettings.get_global_class_list(), which is an allowlist of classes registered via class_name in the user's project.

Closes #95.