### PR TITLE
fix: use resource-root path for update_project_uids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2130,12 +2130,15 @@ class GodotServer {
         );
       }
 
-      // Prepare parameters for the operation (already in camelCase)
+      // Execute using the current project root inside Godot.
+      // Passing the absolute host path through to resave_resources() breaks
+      // because the Godot-side script prefixes non-resource paths with res://,
+      // turning /mnt/... into malformed res:///mnt/....
+      // Explicitly pass a resource-root path so the Godot-side operation stays
+      // inside the active project context without tripping its empty-params check.
       const params = {
-        projectPath: args.projectPath,
+        projectPath: 'res://',
       };
-
-      // Execute the operation
       const { stdout, stderr } = await this.executeOperation('resave_resources', params, args.projectPath);
 
       if (stderr && stderr.includes('Failed to')) {


### PR DESCRIPTION
## Summary
- stop passing the absolute host project path into `resave_resources`
- pass `res://` so the Godot-side operation stays rooted in the active project
- preserve the existing project validation and execution flow

## Why
`update_project_uids` previously passed an absolute host path like `/mnt/c/...` into the Godot-side `resave_resources()` operation. That script prefixes non-resource paths with `res://`, which turned the path into malformed `res:///mnt/...` and caused the tool to process zero files while still reporting success.

This change keeps the operation rooted in the active project by passing `res://` explicitly instead.

## Verification
- `npm run build`
- live MCP probe against Godot `4.6.2.stable.official.71f334935`
- confirmed `update_project_uids` now reports:
  - `Using project path: res://`
  - `Found 3 scenes`
  - `Found 1 scripts/shaders`

Closes #102
