### PR TITLE
feat: add quit_godot tool to close launched editor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,8 @@ class GodotServer {
   private operationsScriptPath: string;
   private validatedPaths: Map<string, boolean> = new Map();
   private strictPathValidation: boolean = false;
+  // Track the editor process spawned by launch_editor so quit_godot can close it
+  private editorProcess: any = null;
 
   /**
    * Parameter name mappings between snake_case and camelCase
@@ -397,6 +399,13 @@ class GodotServer {
       this.logDebug('Killing active Godot process');
       this.activeProcess.process.kill();
       this.activeProcess = null;
+    }
+    if (this.editorProcess) {
+      this.logDebug('Killing tracked editor process');
+      try {
+        this.editorProcess.kill();
+      } catch (_) {}
+      this.editorProcess = null;
     }
     await this.server.close();
   }
@@ -923,6 +932,15 @@ class GodotServer {
             required: ['projectPath'],
           },
         },
+        {
+          name: 'quit_godot',
+          description: 'Close the Godot editor that was launched by this MCP server via launch_editor. Only closes editors spawned by this server.',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+          },
+        },
       ],
     }));
 
@@ -958,6 +976,8 @@ class GodotServer {
           return await this.handleGetUid(request.params.arguments);
         case 'update_project_uids':
           return await this.handleUpdateProjectUids(request.params.arguments);
+        case 'quit_godot':
+          return await this.handleQuitGodot();
         default:
           throw new McpError(
             ErrorCode.MethodNotFound,
@@ -1019,6 +1039,16 @@ class GodotServer {
       this.logDebug(`Launching Godot editor for project: ${args.projectPath}`);
       const process = spawn(this.godotPath, ['-e', '--path', args.projectPath], {
         stdio: 'pipe',
+      });
+
+      // Track the spawned editor so quit_godot can close it later
+      this.editorProcess = process;
+
+      process.on('exit', () => {
+        if (this.editorProcess === process) {
+          this.logDebug('Godot editor exited naturally');
+          this.editorProcess = null;
+        }
       });
 
       process.on('error', (err: Error) => {
@@ -2166,6 +2196,40 @@ class GodotServer {
         ]
       );
     }
+  }
+
+  /**
+   * Handle the quit_godot tool
+   */
+  private async handleQuitGodot() {
+    if (!this.editorProcess) {
+      return this.createErrorResponse(
+        'No Godot editor process is currently tracked',
+        ['The editor may have been closed already, or launch_editor was not used to start it']
+      );
+    }
+
+    try {
+      this.logDebug('Quitting Godot editor');
+      this.editorProcess.kill();
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return this.createErrorResponse(
+        `Failed to quit Godot editor: ${errorMessage}`,
+        ['The process may have already exited']
+      );
+    } finally {
+      this.editorProcess = null;
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: 'Godot editor closed successfully.',
+        },
+      ],
+    };
   }
 
   /**


### PR DESCRIPTION
# feat: add quit_godot tool to close launched editor

## Summary

Add a `quit_godot` tool that closes the Godot editor instance launched by this MCP server via `launch_editor`. The server tracks only editors it spawned, so this tool will never affect unrelated processes.

## Changes

- Added `private editorProcess` field to track the spawned editor process
- Updated `cleanup()` to kill tracked editor on server shutdown
- Registered `quit_godot` in tools list with proper schema (no parameters required)
- Modified `handleLaunchEditor()` to store process reference and clear it on natural exit
- Created `handleQuitGodot()` handler that kills the tracked process or returns error if none is active

## Verification

Builds successfully with no TypeScript errors.