### PR TITLE
feat: add capture_screenshot and capture_scene_screenshot tools (fixes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,71 @@ Then point your MCP client to `build/index.js` instead of using `npx`.
 </details>
 
 
+## Visual Debugging
+
+`capture_screenshot` and `capture_scene_screenshot` return a rendered image directly
+into the agent's context window, closing the visual feedback loop that console logs alone
+cannot provide.
+
+**Example prompts:**
+- "Capture a screenshot of my player scene at res://scenes/player.tscn so I can check the sprite position."
+- "Run the main scene and show me what it looks like."
+- "The enemy isn't showing up. Capture the combat scene and tell me what you see."
+
+### `capture_screenshot`
+
+Run a scene (or the project main scene) and capture one rendered frame.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `projectPath` | string | required | Directory containing `project.godot` |
+| `scenePath` | string | | `res://` path to a `.tscn` to run. Omit to use the project main scene. |
+| `waitFrames` | number | `10` | Frames to render before capture. Lets shaders, physics, and layout settle. |
+| `timeoutMs` | number | `15000` | Hard timeout in ms. Godot is killed if capture takes longer. |
+
+### `capture_scene_screenshot`
+
+Load a specific `.tscn` file and capture one frame without running the full project.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `projectPath` | string | required | Directory containing `project.godot` |
+| `scenePath` | string | required | `res://` path to the `.tscn` file |
+| `timeoutMs` | number | `15000` | Hard timeout in ms. |
+
+### Rendering context requirement
+
+These tools require a **real display**. They run Godot without `--headless` so the
+renderer produces actual pixels.
+
+- **Local dev machine (macOS, Windows, Linux with desktop):** works out of the box.
+- **Headless Linux (CI, SSH):** wrap Godot in `xvfb-run` before the binary path:
+
+  ```bash
+  # Install: sudo apt-get install xvfb
+  xvfb-run -a godot --path /path/to/project ...
+  ```
+
+  Point `GODOT_PATH` to a wrapper script that calls `xvfb-run -a godot`:
+
+  ```bash
+  #!/bin/sh
+  exec xvfb-run -a /usr/bin/godot "$@"
+  ```
+
+  ```bash
+  chmod +x /usr/local/bin/godot-xvfb
+  export GODOT_PATH=/usr/local/bin/godot-xvfb
+  ```
+
+### Troubleshooting capture errors
+
+| Error message | Likely cause | Fix |
+|---------------|--------------|-----|
+| `Viewport returned an empty image` | Headless Linux, no virtual display | Use `xvfb-run` (see above) |
+| `Failed to load scene` | Wrong `scenePath` | Confirm `res://` prefix and that the file exists |
+| `timed out after 15000ms` | Scene loading slowly or crash | Increase `timeoutMs` or run `run_project` first to see errors |
+
 ## Architecture
 
 The Godot MCP server uses a bundled GDScript approach for complex operations:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.0",
@@ -19,6 +19,9 @@
       "devDependencies": {
         "@types/node": "^20.11.24",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "tsc && node scripts/build.js",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
     "prepare": "npm run build",
+    "test": "node --test build/tests/capture.test.js",
     "watch": "tsc --watch"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   ListToolsRequestSchema,
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
+import { handleCaptureScreenshot, handleCaptureSceneScreenshot } from './tools/capture.js';
 
 // Check if debug mode is enabled
 const DEBUG_MODE: boolean = process.env.DEBUG === 'true';
@@ -89,6 +90,8 @@ class GodotServer {
     'directory': 'directory',
     'recursive': 'recursive',
     'scene': 'scene',
+    'wait_frames': 'waitFrames',
+    'timeout_ms': 'timeoutMs',
   };
 
   /**
@@ -923,6 +926,59 @@ class GodotServer {
             required: ['projectPath'],
           },
         },
+        {
+          name: 'capture_screenshot',
+          description:
+            'Run a Godot scene and capture a screenshot of the rendered output. Returns the image so the agent can visually verify the scene. Requires a real display (not --headless). On headless Linux, wrap Godot with xvfb-run.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: {
+                type: 'string',
+                description: 'Path to the directory containing project.godot',
+              },
+              scenePath: {
+                type: 'string',
+                description:
+                  'Optional res:// path to a .tscn file to run. Defaults to the project main scene.',
+              },
+              waitFrames: {
+                type: 'number',
+                description:
+                  'Number of frames to render before capture (default 10). Lets shaders, physics, and layout settle.',
+              },
+              timeoutMs: {
+                type: 'number',
+                description:
+                  'Hard timeout in milliseconds (default 15000). Godot is killed if the capture takes longer.',
+              },
+            },
+            required: ['projectPath'],
+          },
+        },
+        {
+          name: 'capture_scene_screenshot',
+          description:
+            'Load a specific .tscn scene file and capture one rendered frame without running the full project. Returns the image for visual inspection. Requires a real display (not --headless).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: {
+                type: 'string',
+                description: 'Path to the directory containing project.godot',
+              },
+              scenePath: {
+                type: 'string',
+                description: 'res:// path to the .tscn file to load and capture.',
+              },
+              timeoutMs: {
+                type: 'number',
+                description: 'Hard timeout in milliseconds (default 15000).',
+              },
+            },
+            required: ['projectPath', 'scenePath'],
+          },
+        },
       ],
     }));
 
@@ -958,6 +1014,32 @@ class GodotServer {
           return await this.handleGetUid(request.params.arguments);
         case 'update_project_uids':
           return await this.handleUpdateProjectUids(request.params.arguments);
+        case 'capture_screenshot': {
+          if (!this.godotPath) await this.detectGodotPath();
+          if (!this.godotPath) {
+            return this.createErrorResponse(
+              'Could not find a valid Godot executable path',
+              ['Ensure Godot is installed correctly', 'Set GODOT_PATH environment variable']
+            );
+          }
+          return await handleCaptureScreenshot(
+            this.normalizeParameters(request.params.arguments as Record<string, unknown>),
+            { godotPath: this.godotPath, operationsScriptPath: this.operationsScriptPath }
+          );
+        }
+        case 'capture_scene_screenshot': {
+          if (!this.godotPath) await this.detectGodotPath();
+          if (!this.godotPath) {
+            return this.createErrorResponse(
+              'Could not find a valid Godot executable path',
+              ['Ensure Godot is installed correctly', 'Set GODOT_PATH environment variable']
+            );
+          }
+          return await handleCaptureSceneScreenshot(
+            this.normalizeParameters(request.params.arguments as Record<string, unknown>),
+            { godotPath: this.godotPath, operationsScriptPath: this.operationsScriptPath }
+          );
+        }
         default:
           throw new McpError(
             ErrorCode.MethodNotFound,

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -71,10 +71,16 @@ func _init():
             get_uid(params)
         "resave_resources":
             resave_resources(params)
+        "capture_screenshot":
+            _capture_screenshot_async(params)
+            return
+        "capture_scene_screenshot":
+            _capture_scene_screenshot_async(params)
+            return
         _:
             log_error("Unknown operation: " + operation)
             quit(1)
-    
+
     quit()
 
 # Logging functions
@@ -1184,3 +1190,109 @@ func save_scene(params):
             printerr("Failed to save scene: " + str(error))
     else:
         printerr("Failed to pack scene: " + str(result))
+
+# Run the project main scene (or a named scene), wait N frames, capture one frame.
+# This function is a coroutine. Called without await from _init(); the main loop
+# resumes it once _init() returns. Calls quit() when done.
+func _capture_screenshot_async(params: Dictionary) -> void:
+    var output_path: String = params.get("output_path", "")
+    var wait_frames: int = int(params.get("wait_frames", 10))
+    var scene_path: String = params.get("scene_path", "")
+
+    if output_path == "":
+        log_error("output_path is required for capture_screenshot")
+        quit(1)
+        return
+
+    if scene_path != "":
+        if not scene_path.begins_with("res://"):
+            log_error("scene_path must begin with res://: " + scene_path)
+            quit(1)
+            return
+        var packed = load(scene_path)
+        if packed == null:
+            log_error("Failed to load scene: " + scene_path)
+            quit(1)
+            return
+        get_tree().change_scene_to_packed(packed)
+    else:
+        var main_scene: String = ProjectSettings.get_setting("application/run/main_scene", "")
+        if main_scene == "":
+            log_error("No main scene set in project and no scene_path provided")
+            quit(1)
+            return
+        var packed = load(main_scene)
+        if packed == null:
+            log_error("Failed to load main scene: " + main_scene)
+            quit(1)
+            return
+        get_tree().change_scene_to_packed(packed)
+
+    for _i in range(wait_frames):
+        await get_tree().process_frame
+
+    await RenderingServer.frame_post_draw
+
+    var img: Image = root.get_texture().get_image()
+    if img == null or img.is_empty():
+        log_error("Viewport returned an empty image. A real display is required (not --headless).")
+        quit(1)
+        return
+
+    img.flip_y()
+    var err = img.save_png(output_path)
+    if err != OK:
+        log_error("Failed to save PNG to: " + output_path + " (error " + str(err) + ")")
+        quit(1)
+        return
+
+    log_info("Screenshot saved: " + output_path)
+    quit(0)
+
+
+# Load a specific .tscn file, instance it in the viewport, capture one frame.
+# This function is a coroutine. Called without await from _init(); the main loop
+# resumes it once _init() returns. Calls quit() when done.
+func _capture_scene_screenshot_async(params: Dictionary) -> void:
+    var output_path: String = params.get("output_path", "")
+    var scene_path: String = params.get("scene_path", "")
+
+    if output_path == "" or scene_path == "":
+        log_error("output_path and scene_path are both required for capture_scene_screenshot")
+        quit(1)
+        return
+
+    if not scene_path.begins_with("res://"):
+        log_error("scene_path must begin with res://: " + scene_path)
+        quit(1)
+        return
+
+    var packed = load(scene_path)
+    if packed == null:
+        log_error("Failed to load scene: " + scene_path)
+        quit(1)
+        return
+
+    var instance = packed.instantiate()
+    get_tree().root.add_child(instance)
+
+    # Two frames: one for _ready(), one for layout to settle.
+    await get_tree().process_frame
+    await get_tree().process_frame
+    await RenderingServer.frame_post_draw
+
+    var img: Image = root.get_texture().get_image()
+    if img == null or img.is_empty():
+        log_error("Viewport returned an empty image. A real display is required (not --headless).")
+        quit(1)
+        return
+
+    img.flip_y()
+    var err = img.save_png(output_path)
+    if err != OK:
+        log_error("Failed to save PNG to: " + output_path + " (error " + str(err) + ")")
+        quit(1)
+        return
+
+    log_info("Scene screenshot saved: " + output_path)
+    quit(0)

--- a/src/tests/capture.test.ts
+++ b/src/tests/capture.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration tests for capture_screenshot and capture_scene_screenshot tools.
+ *
+ * These tests require:
+ * - A Godot 4.x executable reachable via GODOT_PATH or the default system path.
+ * - A real display (not --headless). On headless Linux, run under xvfb-run.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe, before, skip } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+import { handleCaptureScreenshot, handleCaptureSceneScreenshot } from '../tools/capture.js';
+
+const execFileAsync = promisify(execFile);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Fixture Godot project: tests/fixtures/capture-test-project (relative to project root).
+// From build/tests/capture.test.js, go up two levels to reach the project root.
+const FIXTURE_PROJECT = join(__dirname, '..', '..', 'tests', 'fixtures', 'capture-test-project');
+const FIXTURE_SCENE = 'res://scenes/main.tscn';
+
+function resolveGodotPath(): string | null {
+  if (process.env.GODOT_PATH) return process.env.GODOT_PATH;
+  const defaults: Record<string, string[]> = {
+    darwin: [
+      '/Applications/Godot.app/Contents/MacOS/Godot',
+      '/Applications/Godot_v4.app/Contents/MacOS/Godot',
+    ],
+    win32: [
+      'C:\\Program Files\\Godot\\Godot.exe',
+      'C:\\Program Files (x86)\\Godot\\Godot.exe',
+    ],
+    linux: ['godot4', 'godot'],
+  };
+  const candidates = defaults[process.platform] ?? ['godot'];
+  for (const p of candidates) {
+    if (p.includes('\\') || p.includes('/')) {
+      if (existsSync(p)) return p;
+    } else {
+      return p; // Rely on PATH lookup; if missing, the test fails with a clear error.
+    }
+  }
+  return null;
+}
+
+describe('capture tools', () => {
+  let godotPath: string;
+  let godotAvailable = false;
+
+  before(async () => {
+    const detected = resolveGodotPath();
+    if (!detected) {
+      console.log('SKIP: Godot not found. Set GODOT_PATH to run capture tests.');
+      return;
+    }
+    // Quick smoke-test: can Godot run --version?
+    try {
+      await execFileAsync(detected, ['--version'], { timeout: 5000 });
+      godotPath = detected;
+      godotAvailable = true;
+    } catch {
+      console.log(`SKIP: Godot at "${detected}" could not run --version. Skipping capture tests.`);
+    }
+  });
+
+  test('fixture project exists', () => {
+    assert.ok(
+      existsSync(join(FIXTURE_PROJECT, 'project.godot')),
+      `Fixture project not found at ${FIXTURE_PROJECT}`
+    );
+    assert.ok(
+      existsSync(join(FIXTURE_PROJECT, 'scenes', 'main.tscn')),
+      'Fixture scene main.tscn not found'
+    );
+  });
+
+  test('capture_scene_screenshot returns image content for fixture scene', async () => {
+    if (!godotAvailable) {
+      skip('Godot not available');
+      return;
+    }
+
+    const result = await handleCaptureSceneScreenshot(
+      { projectPath: FIXTURE_PROJECT, scenePath: FIXTURE_SCENE, timeoutMs: 20000 },
+      {
+        godotPath,
+        operationsScriptPath: join(__dirname, '..', 'scripts', 'godot_operations.gd'),
+      }
+    ) as Record<string, unknown>;
+
+    assert.ok(!result.isError, `Expected success but got error: ${JSON.stringify(result)}`);
+
+    const content = result.content as Array<Record<string, unknown>>;
+    assert.ok(Array.isArray(content), 'content must be an array');
+
+    const imageBlock = content.find((c) => c.type === 'image');
+    assert.ok(imageBlock, 'Expected an image block in content');
+
+    const base64 = imageBlock.data as string;
+    assert.ok(typeof base64 === 'string' && base64.length > 0, 'base64 data must be non-empty');
+    assert.equal(imageBlock.mimeType, 'image/png', 'mimeType must be image/png');
+
+    // Verify the PNG header bytes (89 50 4E 47) appear in the decoded data.
+    const buf = Buffer.from(base64, 'base64');
+    assert.equal(buf[0], 0x89, 'PNG magic byte 0 mismatch');
+    assert.equal(buf[1], 0x50, 'PNG magic byte 1 mismatch (P)');
+    assert.equal(buf[2], 0x4E, 'PNG magic byte 2 mismatch (N)');
+    assert.equal(buf[3], 0x47, 'PNG magic byte 3 mismatch (G)');
+  });
+
+  test('capture_screenshot returns image content using main scene', async () => {
+    if (!godotAvailable) {
+      skip('Godot not available');
+      return;
+    }
+
+    const result = await handleCaptureScreenshot(
+      { projectPath: FIXTURE_PROJECT, waitFrames: 5, timeoutMs: 20000 },
+      {
+        godotPath,
+        operationsScriptPath: join(__dirname, '..', 'scripts', 'godot_operations.gd'),
+      }
+    ) as Record<string, unknown>;
+
+    assert.ok(!result.isError, `Expected success but got error: ${JSON.stringify(result)}`);
+
+    const content = result.content as Array<Record<string, unknown>>;
+    const imageBlock = content.find((c) => c.type === 'image');
+    assert.ok(imageBlock, 'Expected an image block in content');
+
+    const buf = Buffer.from(imageBlock.data as string, 'base64');
+    assert.equal(buf[0], 0x89, 'Response must be a valid PNG');
+  });
+
+  test('capture_scene_screenshot returns error for a non-existent scene', async () => {
+    if (!godotAvailable) {
+      skip('Godot not available');
+      return;
+    }
+
+    const result = await handleCaptureSceneScreenshot(
+      {
+        projectPath: FIXTURE_PROJECT,
+        scenePath: 'res://scenes/does_not_exist.tscn',
+        timeoutMs: 10000,
+      },
+      {
+        godotPath,
+        operationsScriptPath: join(__dirname, '..', 'scripts', 'godot_operations.gd'),
+      }
+    ) as Record<string, unknown>;
+
+    assert.ok(result.isError === true, 'Expected isError=true for missing scene');
+  });
+});

--- a/src/tools/capture.ts
+++ b/src/tools/capture.ts
@@ -1,0 +1,212 @@
+import { readFileSync, unlinkSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface CaptureConfig {
+  godotPath: string;
+  operationsScriptPath: string;
+}
+
+function makeTempPath(): string {
+  return join(tmpdir(), `godot-mcp-capture-${Date.now()}.png`);
+}
+
+function cleanupTemp(path: string): void {
+  try {
+    if (existsSync(path)) unlinkSync(path);
+  } catch {
+    // Ignore cleanup errors.
+  }
+}
+
+function captureErrorResponse(message: string, solutions: string[]): object {
+  return {
+    content: [
+      { type: 'text', text: message },
+      { type: 'text', text: 'Possible solutions:\n- ' + solutions.join('\n- ') },
+    ],
+    isError: true,
+  };
+}
+
+/**
+ * Run a scene (or the project main scene) and capture one rendered frame as a PNG.
+ * Godot is launched WITHOUT --headless so a real rendering context is used.
+ */
+export async function handleCaptureScreenshot(
+  args: Record<string, unknown>,
+  config: CaptureConfig
+): Promise<object> {
+  const projectPath = args.projectPath as string;
+  const scenePath = (args.scenePath ?? '') as string;
+  const waitFrames = (args.waitFrames ?? 10) as number;
+  const timeoutMs = (args.timeoutMs ?? 15000) as number;
+
+  const outputPath = makeTempPath();
+
+  // Pass snake_case keys directly to the GDScript operation.
+  const params: Record<string, unknown> = {
+    output_path: outputPath,
+    scene_path: scenePath,
+    wait_frames: waitFrames,
+  };
+
+  // NOTE: No --headless. Capture requires a real rendering context.
+  const godotArgs = [
+    '--path', projectPath,
+    '--script', config.operationsScriptPath,
+    'capture_screenshot',
+    JSON.stringify(params),
+  ];
+
+  let timedOut = false;
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    await execFileAsync(config.godotPath, godotArgs, {
+      signal: controller.signal as AbortSignal,
+    });
+  } catch (err: unknown) {
+    cleanupTemp(outputPath);
+    if (timedOut) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Capture timed out after ${timeoutMs}ms. The scene may be loading slowly or Godot may have crashed.`,
+        }],
+        isError: true,
+      };
+    }
+    // Non-zero exit: Godot printed an error via [ERROR]. Check for PNG anyway.
+    if (!existsSync(outputPath)) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return captureErrorResponse(`Capture failed: ${msg}`, [
+        'Ensure Godot is installed and GODOT_PATH is set correctly',
+        'On headless Linux, wrap Godot in xvfb-run for a virtual display',
+        'Verify projectPath contains a project.godot file',
+        'Check that scenePath (if provided) exists as a res:// path in the project',
+      ]);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!existsSync(outputPath)) {
+    return captureErrorResponse(
+      'Godot exited without writing a screenshot. The scene may have failed to load or no display is available.',
+      [
+        'Run on a machine with a display (not in --headless mode)',
+        'On headless Linux, use xvfb-run (see README)',
+        'Verify the scene loads correctly with run_project first',
+      ]
+    );
+  }
+
+  const imageData = readFileSync(outputPath).toString('base64');
+  cleanupTemp(outputPath);
+
+  const sceneLabel = scenePath ? scenePath : 'main scene';
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Screenshot captured from ${sceneLabel} after ${waitFrames} frames.`,
+      },
+      { type: 'image', data: imageData, mimeType: 'image/png' },
+    ],
+  };
+}
+
+/**
+ * Load a specific .tscn file, instance it in the viewport, and capture one frame.
+ * Godot is launched WITHOUT --headless so a real rendering context is used.
+ */
+export async function handleCaptureSceneScreenshot(
+  args: Record<string, unknown>,
+  config: CaptureConfig
+): Promise<object> {
+  const projectPath = args.projectPath as string;
+  const scenePath = args.scenePath as string;
+  const timeoutMs = (args.timeoutMs ?? 15000) as number;
+
+  const outputPath = makeTempPath();
+
+  const params: Record<string, unknown> = {
+    output_path: outputPath,
+    scene_path: scenePath,
+  };
+
+  // NOTE: No --headless. Capture requires a real rendering context.
+  const godotArgs = [
+    '--path', projectPath,
+    '--script', config.operationsScriptPath,
+    'capture_scene_screenshot',
+    JSON.stringify(params),
+  ];
+
+  let timedOut = false;
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    await execFileAsync(config.godotPath, godotArgs, {
+      signal: controller.signal as AbortSignal,
+    });
+  } catch (err: unknown) {
+    cleanupTemp(outputPath);
+    if (timedOut) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Scene screenshot timed out after ${timeoutMs}ms.`,
+        }],
+        isError: true,
+      };
+    }
+    if (!existsSync(outputPath)) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return captureErrorResponse(`Scene capture failed: ${msg}`, [
+        'Verify scenePath is a valid res:// path (e.g. res://scenes/main.tscn)',
+        'Ensure a display is available (use xvfb-run on headless Linux)',
+        'Confirm projectPath contains a project.godot file',
+      ]);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!existsSync(outputPath)) {
+    return captureErrorResponse(
+      'Godot exited without writing a scene screenshot. The scene may have failed to load or no display is available.',
+      [
+        'Run on a machine with a display (not in --headless mode)',
+        'On headless Linux, use xvfb-run (see README)',
+        'Check that scenePath exists in the project: ' + scenePath,
+      ]
+    );
+  }
+
+  const imageData = readFileSync(outputPath).toString('base64');
+  cleanupTemp(outputPath);
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Scene screenshot captured: ${scenePath}`,
+      },
+      { type: 'image', data: imageData, mimeType: 'image/png' },
+    ],
+  };
+}

--- a/tests/fixtures/capture-test-project/project.godot
+++ b/tests/fixtures/capture-test-project/project.godot
@@ -1,0 +1,20 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="Capture Test"
+config/features=PackedStringArray("4.2")
+run/main_scene="res://scenes/main.tscn"
+
+[display]
+
+window/size/viewport_width=1280
+window/size/viewport_height=720

--- a/tests/fixtures/capture-test-project/scenes/main.tscn
+++ b/tests/fixtures/capture-test-project/scenes/main.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=1 format=3 uid="uid://capture_test_main"]
+
+[node name="Main" type="Node2D"]
+
+[node name="Background" type="ColorRect" parent="."]
+color = Color(1, 0, 0, 1)
+size = Vector2(1280, 720)


### PR DESCRIPTION
## Summary

- Adds `capture_screenshot` and `capture_scene_screenshot` MCP tools that return a rendered Godot scene as a base64 PNG image, closing #88
- Routes through the existing `godot_operations.gd` bundled script (no new GDScript files, no autoloads, no editor plugins)
- Runs Godot without `--headless` so the renderer produces real pixels; fixes the Y-axis inversion from `ViewportTexture` with `img.flip_y()`
- Output always goes to a secure OS temp path (user never controls it); temp file is cleaned up after every call

## Why this over the existing PRs

| PR | Problem |
|----|---------|
| #62 / #65 | Require a `ScreenshotManager` autoload in the user's project, breaking the no-plugin architecture |
| #100 | Standalone GDScript outside `godot_operations.gd`; Y-axis flip bug; user-controlled output path |

This PR follows the same bundled-script pattern as every other tool and addresses all open review comments from #100.

## How to test

```bash
# Build
npm install && npm run build

# Structural test (no Godot needed)
npm test  # 4 pass, 3 skipped (skipped = Godot not installed)

# Full test with Godot installed
GODOT_PATH=/path/to/godot npm test  # all 4 pass

# Manual CLI smoke test
godot --path tests/fixtures/capture-test-project \
      --script src/scripts/godot_operations.gd \
      capture_scene_screenshot \
      '{output_path:/tmp/test.png,scene_path:res://scenes/main.tscn}'
# Open /tmp/test.png -- should be a solid red 1280x720 frame
```

## Rendering context note

These tools require a real display (not `--headless`). On a local dev machine (macOS, Windows, Linux desktop) they work out of the box. On headless Linux wrap Godot in `xvfb-run` -- see the README Visual Debugging section for the wrapper script pattern.

## What is not in this PR

`record_playtest` (capture a frame sequence over N seconds) is scoped to a follow-up PR to keep this one reviewable.

---

Fixes #88