### PR TITLE
Add a headless authoring layer (animation, collision, tilemaps, input, project config, +11 ops)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.0",
@@ -19,6 +19,9 @@
       "devDependencies": {
         "@types/node": "^20.11.24",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/src/godotOpServer.ts
+++ b/src/godotOpServer.ts
@@ -1,0 +1,222 @@
+import { spawn, ChildProcess } from 'node:child_process';
+import net from 'node:net';
+
+/**
+ * Manages a warm ("resident") Godot process per project, so a run of authoring ops costs
+ * ONE Godot boot instead of one-per-op. Each resident runs godot_operations.gd in `__serve`
+ * mode (a TCP request/reply loop). This class:
+ *   - starts a resident on first op for a project, reads its port, connects,
+ *   - SERIALIZES ops per project (one request in flight — respects Godot's concurrency limits),
+ *   - correlates replies by id, times out, and
+ *   - on any crash/close, fails the in-flight ops and drops the resident so the next call
+ *     transparently restarts it. Callers fall back to spawn-per-op on failure, so the resident
+ *     is always an optimization, never a hard dependency.
+ * Note: the resident acks mutating ops (which persist their own .tscn). Ops that RETURN data
+ * (e.g. get_scene_tree) should NOT be routed here — keep them spawn-per-op.
+ */
+export interface OpResult {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  /** recent resident stdout/stderr, for logging + fallback diagnostics */
+  stdout: string;
+}
+
+interface Pending {
+  resolve: (msg: any) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface Resident {
+  proc: ChildProcess;
+  socket: net.Socket | null;
+  ready: Promise<void>;
+  port: number | null;
+  buf: string;
+  pending: Map<number, Pending>;
+  nextId: number;
+  tail: Promise<unknown>;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+  dead: boolean;
+  stdout: string[];
+}
+
+export class GodotOpServer {
+  private residents = new Map<string, Resident>();
+
+  constructor(
+    private readonly getGodotPath: () => string | null,
+    private readonly scriptPath: string,
+    private readonly log: (m: string) => void,
+    private readonly idleMs = 90_000,
+    private readonly callTimeoutMs = 180_000,
+    private readonly readyTimeoutMs = 30_000,
+  ) {}
+
+  /** Run one op on the project's resident (starting/serializing/restarting as needed). */
+  async call(projectPath: string, op: string, params: unknown): Promise<OpResult> {
+    const r = await this.ensure(projectPath);
+    const run = () => this.send(r, op, params);
+    const next = r.tail.then(run, run);
+    r.tail = next.catch(() => {});
+    return next as Promise<OpResult>;
+  }
+
+  private async ensure(projectPath: string): Promise<Resident> {
+    const existing = this.residents.get(projectPath);
+    if (existing && !existing.dead) {
+      await existing.ready.catch(() => {});
+      if (!existing.dead) return existing;
+    }
+    const r = this.startResident(projectPath);
+    this.residents.set(projectPath, r);
+    await r.ready;
+    return r;
+  }
+
+  private startResident(projectPath: string): Resident {
+    const godot = this.getGodotPath();
+    if (!godot) throw new Error('no Godot path available for resident');
+    const proc = spawn(
+      godot,
+      ['--headless', '--path', projectPath, '--script', this.scriptPath, '__serve', '{}'],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    const r: Resident = {
+      proc, socket: null, port: null, buf: '', pending: new Map(), nextId: 1,
+      tail: Promise.resolve(), idleTimer: null, dead: false, stdout: [],
+      ready: undefined as unknown as Promise<void>,
+    };
+    let resolveReady!: () => void;
+    let rejectReady!: (e: unknown) => void;
+    r.ready = new Promise<void>((res, rej) => { resolveReady = res; rejectReady = rej; });
+    const readyTimer = setTimeout(() => {
+      rejectReady(new Error('resident did not become ready in time'));
+      this.markDead(projectPath, r, 'ready timeout');
+    }, this.readyTimeoutMs);
+
+    let outbuf = '';
+    const pushLog = (line: string) => {
+      if (!line.trim()) return;
+      r.stdout.push(line);
+      if (r.stdout.length > 200) r.stdout.splice(0, r.stdout.length - 200);
+    };
+
+    proc.stdout!.on('data', (d: Buffer) => {
+      outbuf += d.toString();
+      if (r.port == null) {
+        const mp = outbuf.match(/LEON_OP_SERVER_PORT (\d+)/);
+        if (mp) r.port = Number(mp[1]);
+      }
+      // Connect as soon as we know the port — the resident prints its READY marker only
+      // AFTER accepting our connection, so waiting for READY before connecting deadlocks.
+      if (r.port != null && !r.socket) {
+        this.connect(projectPath, r, resolveReady, readyTimer);
+      }
+      const lines = outbuf.split('\n');
+      outbuf = lines.pop() ?? '';
+      for (const l of lines) pushLog(l);
+    });
+    proc.stderr!.on('data', (d: Buffer) => {
+      for (const l of d.toString().split('\n')) pushLog(l.trim() ? '[gd] ' + l : '');
+    });
+    proc.on('exit', (code) => { clearTimeout(readyTimer); this.markDead(projectPath, r, `process exited (${code})`); });
+    proc.on('error', (e) => { clearTimeout(readyTimer); rejectReady(e); this.markDead(projectPath, r, String(e)); });
+    return r;
+  }
+
+  private connect(projectPath: string, r: Resident, resolveReady: () => void, readyTimer: ReturnType<typeof setTimeout>) {
+    const sock = net.connect(r.port!, '127.0.0.1');
+    r.socket = sock;
+    sock.setNoDelay(true);
+    sock.on('connect', () => { clearTimeout(readyTimer); resolveReady(); });
+    sock.on('data', (buf: Buffer) => {
+      r.buf += buf.toString();
+      let i: number;
+      while ((i = r.buf.indexOf('\n')) >= 0) {
+        const line = r.buf.slice(0, i);
+        r.buf = r.buf.slice(i + 1);
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          const pend = r.pending.get(msg.id);
+          if (pend) { clearTimeout(pend.timer); r.pending.delete(msg.id); pend.resolve(msg); }
+        } catch { /* ignore malformed line */ }
+      }
+    });
+    sock.on('error', () => { /* close handler does the cleanup */ });
+    sock.on('close', () => this.markDead(projectPath, r, 'socket closed'));
+  }
+
+  // Parity with the spawn path, which flags an op as failed when Godot printed one of these
+  // to stderr (a handler that couldn't find a node / resource logs but doesn't crash).
+  private static readonly ERR_MARKERS = /Failed to|not found|does not exist|has no signal/;
+
+  private send(r: Resident, op: string, params: unknown): Promise<OpResult> {
+    return new Promise<OpResult>((resolve) => {
+      const tail = () => r.stdout.slice(-25).join('\n');
+      if (r.dead || !r.socket) { resolve({ ok: false, error: 'resident not available', stdout: tail() }); return; }
+      const id = r.nextId++;
+      // Remember where this op's output starts so we can scan only ITS lines for errors
+      // (ops are serialized, so nothing else writes in between).
+      const mark = r.stdout.length;
+      const timer = setTimeout(() => {
+        r.pending.delete(id);
+        resolve({ ok: false, error: 'op timed out', stdout: tail() });
+      }, this.callTimeoutMs);
+      r.pending.set(id, {
+        timer,
+        resolve: (msg: any) => {
+          // Let any trailing stderr land (stdout and the TCP reply are separate channels),
+          // then apply the same error detection the spawn path uses.
+          setTimeout(() => {
+            const windowOut = r.stdout.slice(mark).join('\n');
+            if (msg.ok && GodotOpServer.ERR_MARKERS.test(windowOut)) {
+              resolve({ ok: false, error: windowOut.slice(-400), stdout: tail() });
+            } else {
+              resolve({ ok: !!msg.ok, result: msg.result, error: msg.error, stdout: tail() });
+            }
+          }, 25);
+        },
+      });
+      this.resetIdle(r);
+      try {
+        r.socket.write(JSON.stringify({ id, op, params }) + '\n');
+      } catch (e) {
+        clearTimeout(timer);
+        r.pending.delete(id);
+        resolve({ ok: false, error: String(e), stdout: tail() });
+      }
+    });
+  }
+
+  private resetIdle(r: Resident) {
+    if (r.idleTimer) clearTimeout(r.idleTimer);
+    r.idleTimer = setTimeout(() => {
+      if (r.socket && !r.dead) {
+        try { r.socket.write(JSON.stringify({ id: -1, op: '__shutdown', params: {} }) + '\n'); } catch { /* it'll die on its own */ }
+      }
+    }, this.idleMs);
+  }
+
+  private markDead(projectPath: string, r: Resident, why: string) {
+    if (r.dead) return;
+    r.dead = true;
+    if (r.idleTimer) clearTimeout(r.idleTimer);
+    for (const [, p] of r.pending) { clearTimeout(p.timer); p.resolve({ ok: false, error: 'resident died: ' + why }); }
+    r.pending.clear();
+    try { r.socket?.destroy(); } catch { /* noop */ }
+    try { r.proc.kill(); } catch { /* noop */ }
+    if (this.residents.get(projectPath) === r) this.residents.delete(projectPath);
+    this.log(`[op-server] resident for ${projectPath} down: ${why}`);
+  }
+
+  kill(projectPath: string) {
+    const r = this.residents.get(projectPath);
+    if (r) this.markDead(projectPath, r, 'killed');
+  }
+
+  killAll() {
+    for (const k of [...this.residents.keys()]) this.kill(k);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1087,7 +1087,13 @@ class GodotServer {
         this.activeProcess.process.kill();
       }
 
-      const cmdArgs = ['-d', '--path', args.projectPath];
+      // Reduce cross-instance contention when multiple teams/subagents run Godot at
+      // once: silence audio (avoid the shared audio device) and spread the window so
+      // concurrent instances don't perfectly overlap. Keep a real (non-headless)
+      // render so rendering bugs are still visible — headless uses the dummy renderer.
+      const px = 40 + Math.floor(Math.random() * 400);
+      const py = 40 + Math.floor(Math.random() * 200);
+      const cmdArgs = ['-d', '--path', args.projectPath, '--audio-driver', 'Dummy', '--position', `${px},${py}`];
       if (args.scene && this.validatePath(args.scene)) {
         this.logDebug(`Adding scene parameter: ${args.scene}`);
         cmdArgs.push(args.scene);
@@ -1155,14 +1161,27 @@ class GodotServer {
    * Handle the get_debug_output tool
    */
   private async handleGetDebugOutput() {
+    // Return GRACEFULLY (not an error) when there's no active process. An error
+    // tool_result here surfaces to the Agent SDK as `error_during_execution` and
+    // KILLS the whole session — especially under concurrency, when another run
+    // replaced/killed this one. A benign "no active process" is safe.
     if (!this.activeProcess) {
-      return this.createErrorResponse(
-        'No active Godot process.',
-        [
-          'Use run_project to start a Godot project first',
-          'Check if the Godot process crashed unexpectedly',
-        ]
-      );
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                output: [],
+                errors: [],
+                note: 'No active Godot process — it may have finished, been stopped, or been replaced by another run (concurrency). Use run_project to start one.',
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
     }
 
     return {
@@ -1186,14 +1205,11 @@ class GodotServer {
    * Handle the stop_project tool
    */
   private async handleStopProject() {
+    // Graceful (not an error) — see handleGetDebugOutput: an error here can kill the session.
     if (!this.activeProcess) {
-      return this.createErrorResponse(
-        'No active Godot process to stop.',
-        [
-          'Use run_project to start a Godot project first',
-          'The process may have already terminated',
-        ]
-      );
+      return {
+        content: [{ type: 'text', text: 'No active Godot process to stop (already stopped, exited, or replaced by another run).' }],
+      };
     }
 
     this.logDebug('Stopping active Godot process');

--- a/src/index.ts
+++ b/src/index.ts
@@ -818,6 +818,28 @@ func _bounds(root: Node) -> Rect2:
           },
         },
         {
+          name: 'batch_author',
+          description:
+            "Apply an ORDERED list of authoring ops against ONE scene in a SINGLE Godot boot (instead of one boot per op) — the fast path for authoring a whole scene. The scene is loaded once and saved once; if any op fails, the process aborts BEFORE saving so the .tscn is left unchanged (no partial writes). Each ops[] entry is { op: <tool name>, ...that tool's params } (e.g. {op:'add_collision_shape', parentPath:'Player', shape:'rectangle', size:{x:16,y:24}}). Use it for the scene-authoring ops (add_node, add_collision_shape, add_animation, add_animated_sprite, paint_tilemap, add_area2d, set_camera_limits, add_particles, connect_signal, attach_script, set_node_property, instance_scene, remove_node).",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string', description: 'Path to the Godot project directory' },
+              scenePath: { type: 'string', description: 'The .tscn all ops target (res:// or project-relative). Loaded once, saved once.' },
+              ops: {
+                type: 'array',
+                description: "Ordered ops. Each is an object: { op: '<tool name>', ...that op's params }. Applied in order against the one loaded scene.",
+                items: {
+                  type: 'object',
+                  properties: { op: { type: 'string', description: 'The authoring op name, e.g. "add_collision_shape"' } },
+                  required: ['op'],
+                },
+              },
+            },
+            required: ['projectPath', 'scenePath', 'ops'],
+          },
+        },
+        {
           name: 'capture_level_overview',
           description:
             "Render a whole-LEVEL overview PNG of a scene — the top-down \"level-designer's view\" of the entire level (all tilemaps/sprites framed to fit), NOT the in-game camera. Computes the level's world bounds (Camera2D limits if authored, else the union of TileMapLayer/Sprite2D extents), frames an orthographic camera to fit, and captures one real (non-headless) rendered frame. Use it to eyeball level layout, coverage, and composition the way you would in the Godot editor.",
@@ -1339,6 +1361,8 @@ func _bounds(root: Node) -> Rect2:
           return await this.handleAuthoringOp('add_animated_sprite', request.params.arguments, ['parentPath', 'texture']);
         case 'paint_tilemap':
           return await this.handleAuthoringOp('paint_tilemap', request.params.arguments, ['parentPath', 'texture']);
+        case 'batch_author':
+          return await this.handleAuthoringOp('batch_author', request.params.arguments, ['ops']);
         case 'add_area2d':
           return await this.handleAuthoringOp('add_area2d', request.params.arguments, ['parentPath']);
         case 'add_particles':

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@
  */
 
 import { fileURLToPath } from 'url';
-import { join, dirname, basename, normalize } from 'path';
-import { existsSync, readdirSync, mkdirSync } from 'fs';
+import { join, dirname, basename, normalize, isAbsolute } from 'path';
+import { existsSync, readdirSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
 import { spawn, execFile } from 'child_process';
 import { promisify } from 'util';
 
@@ -65,6 +65,124 @@ class GodotServer {
   private server: Server;
   private activeProcess: GodotProcess | null = null;
   private godotPath: string | null = null;
+
+  /**
+   * GDScript template for capture_level_overview. Tokens (__TARGET__, __OUT__,
+   * __MAXW__, __MAXH__, __PAD__) are substituted at runtime. Instances the target
+   * scene, computes the level's world AABB, frames a fitted Camera2D, and saves one
+   * real rendered frame. Lines are flush-left on purpose — GDScript is
+   * indentation-sensitive, so no host-code indentation may leak in.
+   */
+  private static readonly CAPTURE_GD = String.raw`extends Node2D
+# Studio Leon — whole-level overview capture (auto-generated; safe to delete).
+const TARGET_SCENE := "__TARGET__"
+const OUT_PATH := "__OUT__"
+const MAX_W := __MAXW__
+const MAX_H := __MAXH__
+const PAD := __PAD__
+
+func _ready() -> void:
+    var packed = ResourceLoader.load(TARGET_SCENE)
+    if packed == null or not (packed is PackedScene):
+        push_error("LEON_CAPTURE: cannot load scene " + TARGET_SCENE)
+        get_tree().quit(2)
+        return
+    var inst = packed.instantiate()
+    add_child(inst)
+    # let the instanced scene's _ready run and tilemaps populate
+    await get_tree().process_frame
+    await get_tree().process_frame
+    var b := _bounds(inst)
+    if b.size.x <= 1.0 or b.size.y <= 1.0:
+        b = Rect2(Vector2.ZERO, Vector2(1152.0, 648.0))
+    b = b.grow(maxf(b.size.x, b.size.y) * PAD)
+    var ar := b.size.x / b.size.y
+    var ow := MAX_W
+    var oh := int(round(float(MAX_W) / ar))
+    if oh > MAX_H:
+        oh = MAX_H
+        ow = int(round(float(MAX_H) * ar))
+    ow = maxi(ow, 16)
+    oh = maxi(oh, 16)
+    DisplayServer.window_set_size(Vector2i(ow, oh))
+    var vp := get_viewport()
+    var cam := Camera2D.new()
+    add_child(cam)
+    cam.position = b.position + b.size * 0.5
+    var z: float = minf(float(ow) / b.size.x, float(oh) / b.size.y)
+    cam.zoom = Vector2(z, z)
+    cam.make_current()
+    # settle the window resize + camera, then grab exactly one drawn frame
+    for i in range(5):
+        await get_tree().process_frame
+    await RenderingServer.frame_post_draw
+    var img := vp.get_texture().get_image()
+    if img == null:
+        push_error("LEON_CAPTURE: viewport image was null")
+        get_tree().quit(4)
+        return
+    var err := img.save_png(OUT_PATH)
+    if err != OK:
+        push_error("LEON_CAPTURE: save_png failed err=" + str(err))
+        get_tree().quit(3)
+        return
+    print("LEON_CAPTURE_DONE ", OUT_PATH, " ", ow, "x", oh, " bounds=", b)
+    get_tree().quit(0)
+
+func _xf_rect(xf: Transform2D, r: Rect2) -> Rect2:
+    var p0 := xf * r.position
+    var p1 := xf * (r.position + Vector2(r.size.x, 0.0))
+    var p2 := xf * (r.position + Vector2(0.0, r.size.y))
+    var p3 := xf * (r.position + r.size)
+    var mn := Vector2(minf(minf(p0.x, p1.x), minf(p2.x, p3.x)), minf(minf(p0.y, p1.y), minf(p2.y, p3.y)))
+    var mx := Vector2(maxf(maxf(p0.x, p1.x), maxf(p2.x, p3.x)), maxf(maxf(p0.y, p1.y), maxf(p2.y, p3.y)))
+    return Rect2(mn, mx - mn)
+
+func _bounds(root: Node) -> Rect2:
+    var acc := Rect2()
+    var has := false
+    var stack: Array = [root]
+    while not stack.is_empty():
+        var n = stack.pop_back()
+        # a level overview is the world, not the HUD — skip UI overlays
+        if n is CanvasLayer:
+            continue
+        for c in n.get_children():
+            stack.push_back(c)
+        var rr := Rect2()
+        var ok := false
+        if n is Camera2D:
+            var cam := n as Camera2D
+            if cam.limit_left > -10000000 and cam.limit_right < 10000000 and cam.limit_right > cam.limit_left and cam.limit_bottom > cam.limit_top:
+                rr = Rect2(Vector2(cam.limit_left, cam.limit_top), Vector2(cam.limit_right - cam.limit_left, cam.limit_bottom - cam.limit_top))
+                ok = true
+        elif n is TileMapLayer:
+            var tl := n as TileMapLayer
+            var used := tl.get_used_rect()
+            if used.size.x > 0 and used.size.y > 0 and tl.tile_set != null:
+                var ts := Vector2(tl.tile_set.tile_size)
+                var local := Rect2(Vector2(used.position) * ts, Vector2(used.size) * ts)
+                rr = _xf_rect(tl.global_transform, local)
+                ok = true
+        elif n is Sprite2D:
+            var sp := n as Sprite2D
+            if sp.texture != null:
+                rr = _xf_rect(sp.global_transform, sp.get_rect())
+                ok = true
+        elif n is AnimatedSprite2D:
+            var asp := n as AnimatedSprite2D
+            var fr := asp.sprite_frames
+            if fr != null and asp.animation != "" and fr.get_frame_count(asp.animation) > 0:
+                var tex := fr.get_frame_texture(asp.animation, asp.frame)
+                if tex != null:
+                    var sz := tex.get_size()
+                    rr = _xf_rect(asp.global_transform, Rect2(-sz * 0.5, sz))
+                    ok = true
+        if ok:
+            acc = rr if not has else acc.merge(rr)
+            has = true
+    return acc if has else Rect2()
+`;
   private operationsScriptPath: string;
   private validatedPaths: Map<string, boolean> = new Map();
   private strictPathValidation: boolean = false;
@@ -700,6 +818,23 @@ class GodotServer {
           },
         },
         {
+          name: 'capture_level_overview',
+          description:
+            "Render a whole-LEVEL overview PNG of a scene — the top-down \"level-designer's view\" of the entire level (all tilemaps/sprites framed to fit), NOT the in-game camera. Computes the level's world bounds (Camera2D limits if authored, else the union of TileMapLayer/Sprite2D extents), frames an orthographic camera to fit, and captures one real (non-headless) rendered frame. Use it to eyeball level layout, coverage, and composition the way you would in the Godot editor.",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string', description: 'Path to the Godot project directory' },
+              scene: { type: 'string', description: 'Scene to capture — a res:// path or project-relative .tscn (e.g. "res://levels/level1.tscn")' },
+              outputPath: { type: 'string', description: 'Where to write the PNG (absolute, or relative to the project). Default: <project>/.studio/shots/level-overview.png' },
+              maxWidth: { type: 'number', description: 'Max output width in px (default 1920). The level aspect is preserved within maxWidth×maxHeight.' },
+              maxHeight: { type: 'number', description: 'Max output height in px (default 1080).' },
+              padding: { type: 'number', description: 'Fractional margin around the level bounds, 0–0.5 (default 0.06).' },
+            },
+            required: ['projectPath', 'scene'],
+          },
+        },
+        {
           name: 'get_debug_output',
           description: 'Get the current debug output and errors',
           inputSchema: {
@@ -1176,6 +1311,8 @@ class GodotServer {
           return await this.handleLaunchEditor(request.params.arguments);
         case 'run_project':
           return await this.handleRunProject(request.params.arguments);
+        case 'capture_level_overview':
+          return await this.handleCaptureLevelOverview(request.params.arguments);
         case 'get_debug_output':
           return await this.handleGetDebugOutput();
         case 'stop_project':
@@ -1426,6 +1563,153 @@ class GodotServer {
           'Verify the project path is accessible',
         ]
       );
+    }
+  }
+
+  /**
+   * Handle the capture_level_overview tool — render the WHOLE level (the
+   * "level-designer's view"), not the in-game camera. We generate a tiny throwaway
+   * capture scene into the project that: instances the target scene, computes the
+   * level's world AABB (authored Camera2D limits if present, else the union of
+   * TileMapLayer/Sprite2D extents), frames an orthographic Camera2D to fit, and grabs
+   * exactly one REAL (non-headless) rendered frame to a PNG. Headless is useless here —
+   * the dummy renderer produces blank frames — so this runs with the real renderer,
+   * same as run_project. Temp files are cleaned up afterwards.
+   */
+  private async handleCaptureLevelOverview(args: any) {
+    if (!args || !args.projectPath) {
+      return this.createErrorResponse('Project path is required', ['Provide a valid path to a Godot project directory']);
+    }
+    if (!this.validatePath(args.projectPath)) {
+      return this.createErrorResponse('Invalid project path', ['Provide a valid path without ".." or other potentially unsafe characters']);
+    }
+    if (!args.scene) {
+      return this.createErrorResponse('scene is required', ['Provide the .tscn to capture, e.g. "res://levels/level1.tscn"']);
+    }
+    const projectFile = join(args.projectPath, 'project.godot');
+    if (!existsSync(projectFile)) {
+      return this.createErrorResponse(`Not a valid Godot project: ${args.projectPath}`, [
+        'Ensure the path points to a directory containing a project.godot file',
+      ]);
+    }
+
+    if (!this.godotPath) {
+      await this.detectGodotPath();
+      if (!this.godotPath) {
+        return this.createErrorResponse('Could not find a Godot executable', ['Set GODOT_PATH to your Godot binary']);
+      }
+    }
+
+    // Normalise the scene to a res:// path.
+    let resScene: string = String(args.scene);
+    if (!resScene.startsWith('res://')) resScene = 'res://' + resScene.replace(/^\/+/, '');
+
+    // Output PNG — default into the studio shot convention.
+    let outPath: string = args.outputPath ? String(args.outputPath) : join(args.projectPath, '.studio', 'shots', 'level-overview.png');
+    if (!isAbsolute(outPath)) outPath = join(args.projectPath, outPath);
+    try {
+      mkdirSync(dirname(outPath), { recursive: true });
+    } catch {}
+
+    const maxW = Math.min(Math.max(parseInt(String(args.maxWidth ?? 1920), 10) || 1920, 128), 4096);
+    const maxH = Math.min(Math.max(parseInt(String(args.maxHeight ?? 1080), 10) || 1080, 128), 4096);
+    const pad = Math.min(Math.max(Number(args.padding ?? 0.06) || 0.06, 0), 0.5);
+
+    // Throwaway capture scene + script written into the project (so res:// resolves).
+    const stamp = Date.now().toString(36);
+    const gdName = `__leon_capture_${stamp}.gd`;
+    const tscnName = `__leon_capture_${stamp}.tscn`;
+    const gdAbs = join(args.projectPath, gdName);
+    const tscnAbs = join(args.projectPath, tscnName);
+    const gdSource = GodotServer.CAPTURE_GD
+      .replace(/__TARGET__/g, resScene)
+      .replace(/__OUT__/g, outPath.replace(/\\/g, '/'))
+      .replace(/__MAXW__/g, String(maxW))
+      .replace(/__MAXH__/g, String(maxH))
+      .replace(/__PAD__/g, String(pad));
+    const tscnSource =
+      `[gd_scene load_steps=2 format=3]\n\n` +
+      `[ext_resource type="Script" path="res://${gdName}" id="1_cap"]\n\n` +
+      `[node name="LeonCapture" type="Node2D"]\n` +
+      `script = ExtResource("1_cap")\n`;
+
+    const cleanup = () => {
+      for (const f of [gdAbs, tscnAbs, `${gdAbs}.uid`, `${tscnAbs}.uid`, `${gdAbs}.import`, `${tscnAbs}.import`]) {
+        try { unlinkSync(f); } catch {}
+      }
+    };
+
+    try {
+      writeFileSync(gdAbs, gdSource, 'utf8');
+      writeFileSync(tscnAbs, tscnSource, 'utf8');
+
+      // Kill any of OUR older capture/run before spawning (avoid piling up windows).
+      if (this.activeProcess) {
+        try { this.activeProcess.process.kill(); } catch {}
+        this.activeProcess = null;
+      }
+
+      const px = 40 + Math.floor(Math.random() * 400);
+      const py = 40 + Math.floor(Math.random() * 200);
+      const cmdArgs = ['-d', '--path', args.projectPath, '--audio-driver', 'Dummy', '--position', `${px},${py}`, `res://${tscnName}`];
+      this.logDebug(`Capturing level overview: ${resScene} -> ${outPath}`);
+
+      const result = await new Promise<{ code: number | null; out: string; err: string; timedOut: boolean }>((resolve) => {
+        const proc = spawn(this.godotPath!, cmdArgs, { stdio: 'pipe' });
+        let out = '';
+        let err = '';
+        let timedOut = false;
+        const timer = setTimeout(() => {
+          timedOut = true;
+          try { proc.kill('SIGKILL'); } catch {}
+        }, 60000);
+        proc.stdout?.on('data', (d: Buffer) => { out += d.toString(); });
+        proc.stderr?.on('data', (d: Buffer) => { err += d.toString(); });
+        proc.on('exit', (code: number | null) => { clearTimeout(timer); resolve({ code, out, err, timedOut }); });
+        proc.on('error', (e: Error) => { clearTimeout(timer); resolve({ code: -1, out, err: `${err}\n${e.message}`, timedOut }); });
+      });
+
+      const produced = existsSync(outPath);
+      const doneLine = (result.out.split('\n').find((l) => l.includes('LEON_CAPTURE_DONE')) || '').trim();
+
+      if (!produced) {
+        const tail = (result.err || result.out).split('\n').filter(Boolean).slice(-12).join('\n');
+        return this.createErrorResponse(
+          `Level overview capture produced no PNG${result.timedOut ? ' (timed out after 60s)' : ` (exit ${result.code})`}`,
+          [
+            'Confirm the scene path is correct and the scene loads standalone',
+            'The scene needs some visible TileMapLayer/Sprite2D content (or a Camera2D with limits) to frame',
+            'A real display/renderer is required — headless produces blank frames',
+            tail ? `Godot said:\n${tail}` : 'No output captured from Godot',
+          ]
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                savedTo: outPath,
+                scene: resScene,
+                detail: doneLine || `captured (exit ${result.code})`,
+                note: 'Whole-level overview (level-designer view), not the in-game camera. Read the PNG and judge it like an art director.',
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return this.createErrorResponse(`Failed to capture level overview: ${msg}`, [
+        'Ensure Godot is installed and GODOT_PATH is correct',
+        'Verify the project path and scene are accessible',
+      ]);
+    } finally {
+      cleanup();
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { fileURLToPath } from 'url';
+import { GodotOpServer } from './godotOpServer.js';
 import { join, dirname, basename, normalize, isAbsolute } from 'path';
 import { existsSync, readdirSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
 import { spawn, execFile } from 'child_process';
@@ -65,6 +66,8 @@ class GodotServer {
   private server: Server;
   private activeProcess: GodotProcess | null = null;
   private godotPath: string | null = null;
+  /** Warm resident-process pool for authoring ops (opt-in via GODOT_RESIDENT=1). */
+  private opServer: GodotOpServer | null = null;
 
   /**
    * GDScript template for capture_level_overview. Tokens (__TARGET__, __OUT__,
@@ -252,6 +255,18 @@ func _bounds(root: Node) -> Rect2:
     // Set the path to the operations script
     this.operationsScriptPath = join(__dirname, 'scripts', 'godot_operations.gd');
     if (debugMode) console.error(`[DEBUG] Operations script path: ${this.operationsScriptPath}`);
+
+    // Warm resident pool for authoring ops — opt-in (GODOT_RESIDENT=1) so it never changes
+    // behavior unless enabled; when on, authoring ops reuse a warm process and fall back to
+    // spawn-per-op on any resident failure.
+    if (process.env.GODOT_RESIDENT === '1') {
+      this.opServer = new GodotOpServer(
+        () => this.godotPath,
+        this.operationsScriptPath,
+        (m) => this.logDebug(m),
+      );
+      if (debugMode) console.error('[DEBUG] Resident op-server ENABLED (GODOT_RESIDENT=1)');
+    }
 
     // Initialize the MCP server
     this.server = new Server(
@@ -516,6 +531,7 @@ func _bounds(root: Node) -> Rect2:
       this.activeProcess.process.kill();
       this.activeProcess = null;
     }
+    this.opServer?.killAll();
     await this.server.close();
   }
 
@@ -1376,7 +1392,8 @@ func _bounds(root: Node) -> Rect2:
         case 'instance_scene':
           return await this.handleAuthoringOp('instance_scene', request.params.arguments, ['subScene']);
         case 'get_scene_tree':
-          return await this.handleAuthoringOp('get_scene_tree', request.params.arguments, []);
+          // returns the tree on stdout, not a TCP ack — must stay spawn-per-op
+          return await this.handleAuthoringOp('get_scene_tree', request.params.arguments, [], true, false);
         case 'add_input_action':
           return await this.handleAuthoringOp('add_input_action', request.params.arguments, ['action'], false);
         case 'set_project_setting':
@@ -2160,7 +2177,7 @@ func _bounds(root: Node) -> Rect2:
   // Generic handler for the headless AUTHORING-LAYER ops (animation, collision,
   // camera limits, signals, animated sprites, tilemaps, areas, particles). Each
   // validates the project + scene, then drives godot_operations.gd via executeOperation.
-  private async handleAuthoringOp(operation: string, args: any, required: string[], needsScene = true) {
+  private async handleAuthoringOp(operation: string, args: any, required: string[], needsScene = true, residentOk = true) {
     args = this.normalizeParameters(args);
     const need = ['projectPath', ...(needsScene ? ['scenePath'] : []), ...required];
     for (const key of need) {
@@ -2187,6 +2204,34 @@ func _bounds(root: Node) -> Rect2:
     }
     const params: any = { ...args };
     delete params.projectPath;
+
+    // Prefer the warm resident when enabled. It's a pure accelerator: on success we return;
+    // on an INFRA failure (resident died/unavailable — which also covers a handler that
+    // crashed the process BEFORE its save, so nothing persisted) we transparently fall
+    // through to spawn-per-op, which re-runs cleanly and reports the real error. A resident
+    // TIMEOUT is NOT retried (the op may have run), it's surfaced as an error.
+    if (this.opServer && residentOk && needsScene) {
+      const rr = await this.opServer
+        .call(args.projectPath, operation, params)
+        .catch((e: unknown) => ({ ok: false, error: String((e as Error)?.message ?? e), stdout: '' }));
+      if (rr.ok) {
+        return { content: [{ type: 'text', text: `${operation} completed (resident).\n${rr.stdout}`.trim() }] };
+      }
+      const err = rr.error ?? '';
+      const infraFailure = /resident died|not available|ready|become ready|process exited|no Godot|socket closed/.test(err);
+      if (!infraFailure) {
+        return this.createErrorResponse(
+          `${operation} failed: ${err || 'resident error'}`,
+          [
+            'Check the node paths (parentPath/fromPath/toPath) exist in the scene',
+            'Verify any referenced texture path is a res:// resource',
+            rr.stdout ? `Resident output:\n${rr.stdout.slice(-400)}` : '',
+          ].filter(Boolean),
+        );
+      }
+      // infra failure — fall through to the spawn-per-op path below
+    }
+
     try {
       const { stdout, stderr } = await this.executeOperation(operation, params, args.projectPath);
       if (stderr && /Failed to|not found|does not exist|has no signal/.test(stderr)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -962,6 +962,101 @@ class GodotServer {
           },
         },
         {
+          name: 'attach_script',
+          description: 'Attach an existing GDScript (write the .gd first) to a node — this is where game behavior lives.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              nodePath: { type: 'string', description: 'e.g. "root" or "root/Player"' },
+              scriptPath: { type: 'string', description: 'res:// path to the .gd file' },
+            },
+            required: ['projectPath', 'scenePath', 'nodePath', 'scriptPath'],
+          },
+        },
+        {
+          name: 'set_node_property',
+          description: 'Set properties on an existing node (res:// values are loaded as resources).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              nodePath: { type: 'string' },
+              properties: { type: 'object' },
+            },
+            required: ['projectPath', 'scenePath', 'nodePath', 'properties'],
+          },
+        },
+        {
+          name: 'remove_node',
+          description: 'Remove a node from a scene.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              nodePath: { type: 'string' },
+            },
+            required: ['projectPath', 'scenePath', 'nodePath'],
+          },
+        },
+        {
+          name: 'instance_scene',
+          description: 'Instance a sub-scene (a PackedScene / prefab .tscn) as a child — the Godot way to compose (e.g. drop a Player prefab into a Level).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string', description: 'the parent scene to add into' },
+              subScene: { type: 'string', description: 'res:// path to the .tscn to instance' },
+              parentPath: { type: 'string' },
+              name: { type: 'string' },
+              position: { type: 'array', description: '[x,y]' },
+            },
+            required: ['projectPath', 'scenePath', 'subScene'],
+          },
+        },
+        {
+          name: 'get_scene_tree',
+          description: 'Print a scene\'s node tree (name : type, + [script] markers) — inspect what exists before editing.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+            },
+            required: ['projectPath', 'scenePath'],
+          },
+        },
+        {
+          name: 'add_input_action',
+          description: 'Define an InputMap action in project.godot (so Input.is_action_pressed works). Fixes the "verb bound to nothing" bug — declare move/jump/attack here.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              action: { type: 'string', description: 'action name, e.g. "jump"' },
+              events: { type: 'array', description: '[{type:"key", key:"Z"} | {type:"joy_button", button:0} | {type:"mouse_button", button:1}]' },
+              deadzone: { type: 'number' },
+            },
+            required: ['projectPath', 'action'],
+          },
+        },
+        {
+          name: 'set_project_setting',
+          description: 'Set project.godot settings — main scene (application/run/main_scene), window size, stretch mode, physics tick, etc. Run this so the game actually launches at a modern resolution.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              settings: { type: 'object', description: '{ "application/run/main_scene":"res://main.tscn", "display/window/size/viewport_width":1280, ... }' },
+            },
+            required: ['projectPath', 'settings'],
+          },
+        },
+        {
           name: 'load_sprite',
           description: 'Load a sprite into a Sprite2D node',
           inputSchema: {
@@ -1111,6 +1206,20 @@ class GodotServer {
           return await this.handleAuthoringOp('add_area2d', request.params.arguments, ['parentPath']);
         case 'add_particles':
           return await this.handleAuthoringOp('add_particles', request.params.arguments, ['parentPath']);
+        case 'attach_script':
+          return await this.handleAuthoringOp('attach_script', request.params.arguments, ['nodePath', 'scriptPath']);
+        case 'set_node_property':
+          return await this.handleAuthoringOp('set_node_property', request.params.arguments, ['nodePath', 'properties']);
+        case 'remove_node':
+          return await this.handleAuthoringOp('remove_node', request.params.arguments, ['nodePath']);
+        case 'instance_scene':
+          return await this.handleAuthoringOp('instance_scene', request.params.arguments, ['subScene']);
+        case 'get_scene_tree':
+          return await this.handleAuthoringOp('get_scene_tree', request.params.arguments, []);
+        case 'add_input_action':
+          return await this.handleAuthoringOp('add_input_action', request.params.arguments, ['action'], false);
+        case 'set_project_setting':
+          return await this.handleAuthoringOp('set_project_setting', request.params.arguments, ['settings'], false);
         case 'load_sprite':
           return await this.handleLoadSprite(request.params.arguments);
         case 'export_mesh_library':
@@ -1743,9 +1852,9 @@ class GodotServer {
   // Generic handler for the headless AUTHORING-LAYER ops (animation, collision,
   // camera limits, signals, animated sprites, tilemaps, areas, particles). Each
   // validates the project + scene, then drives godot_operations.gd via executeOperation.
-  private async handleAuthoringOp(operation: string, args: any, required: string[]) {
+  private async handleAuthoringOp(operation: string, args: any, required: string[], needsScene = true) {
     args = this.normalizeParameters(args);
-    const need = ['projectPath', 'scenePath', ...required];
+    const need = ['projectPath', ...(needsScene ? ['scenePath'] : []), ...required];
     for (const key of need) {
       if (args[key] === undefined || args[key] === null || args[key] === '') {
         return this.createErrorResponse(`Missing required parameter: ${key}`, [
@@ -1753,7 +1862,7 @@ class GodotServer {
         ]);
       }
     }
-    if (!this.validatePath(args.projectPath) || !this.validatePath(args.scenePath)) {
+    if (!this.validatePath(args.projectPath) || (needsScene && !this.validatePath(args.scenePath))) {
       return this.createErrorResponse('Invalid path', [
         'Provide valid paths without ".." or other unsafe characters',
       ]);
@@ -1763,7 +1872,7 @@ class GodotServer {
         'The path must contain a project.godot file',
       ]);
     }
-    if (!existsSync(join(args.projectPath, args.scenePath))) {
+    if (needsScene && !existsSync(join(args.projectPath, args.scenePath))) {
       return this.createErrorResponse(`Scene file does not exist: ${args.scenePath}`, [
         'Create it with create_scene first',
       ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -815,6 +815,153 @@ class GodotServer {
           },
         },
         {
+          name: 'add_animation',
+          description: 'Author an AnimationPlayer + a keyframed value-track Animation (walk/idle/attack). Use this instead of hand-rolling animation in _process.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string', description: 'Path to the Godot project directory' },
+              scenePath: { type: 'string', description: 'Scene file (relative to project)' },
+              animationName: { type: 'string', description: 'Name of the animation (e.g. "walk")' },
+              playerParent: { type: 'string', description: 'Node to hold the AnimationPlayer (default "root")' },
+              length: { type: 'number', description: 'Animation length in seconds' },
+              loop: { type: 'boolean' },
+              tracks: { type: 'array', description: 'Value tracks: [{ path: "Node:property" e.g. ".:position:y", keys: [{time, value}], interp?: "nearest" }]' },
+            },
+            required: ['projectPath', 'scenePath', 'animationName'],
+          },
+        },
+        {
+          name: 'add_collision_shape',
+          description: 'Add a CollisionShape2D with a real shape to a body (CharacterBody2D/StaticBody2D/RigidBody2D). Fixes floating/no-collision characters.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              parentPath: { type: 'string', description: 'The body to attach the shape to' },
+              shape: { type: 'string', enum: ['rectangle', 'circle', 'capsule'] },
+              size: { type: 'array', description: '[w,h] for rectangle' },
+              radius: { type: 'number' },
+              height: { type: 'number' },
+              position: { type: 'array', description: '[x,y] offset' },
+              name: { type: 'string' },
+            },
+            required: ['projectPath', 'scenePath', 'parentPath'],
+          },
+        },
+        {
+          name: 'set_camera_limits',
+          description: 'Set Camera2D limits (clamp the view to the map so it never scrolls past the edge). Creates the Camera2D if absent.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              cameraPath: { type: 'string' },
+              cameraParent: { type: 'string', description: 'where to create the Camera2D if none (default root)' },
+              limits: { type: 'object', description: '{ left, top, right, bottom }' },
+              smoothing: { type: 'number', description: 'position smoothing speed (optional)' },
+            },
+            required: ['projectPath', 'scenePath'],
+          },
+        },
+        {
+          name: 'connect_signal',
+          description: 'Persistently connect a signal into the scene (serialized to the .tscn) — wire nodes, do not hand-poll.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              fromPath: { type: 'string', description: 'node emitting the signal' },
+              signal: { type: 'string' },
+              toPath: { type: 'string', description: 'node with the handler method' },
+              method: { type: 'string' },
+            },
+            required: ['projectPath', 'scenePath', 'fromPath', 'signal', 'toPath', 'method'],
+          },
+        },
+        {
+          name: 'add_animated_sprite',
+          description: 'Add an AnimatedSprite2D + SpriteFrames built from a sprite-sheet grid — real frame animation from an atlas.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              parentPath: { type: 'string' },
+              texture: { type: 'string', description: 'res:// path to the sprite sheet' },
+              frameWidth: { type: 'number' },
+              frameHeight: { type: 'number' },
+              animations: { type: 'array', description: '[{ name, frames: [frameIndex,...], fps?, loop? }]' },
+              autoplay: { type: 'string' },
+              name: { type: 'string' },
+            },
+            required: ['projectPath', 'scenePath', 'parentPath', 'texture'],
+          },
+        },
+        {
+          name: 'paint_tilemap',
+          description: 'Add a TileMapLayer with a TileSet built from an atlas texture, and paint cells. Use for levels instead of hand-placing sprites.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              parentPath: { type: 'string' },
+              texture: { type: 'string', description: 'res:// path to the tileset atlas' },
+              tileSize: { type: 'number' },
+              cells: { type: 'array', description: '[{ x, y, atlasX, atlasY }]' },
+              name: { type: 'string' },
+            },
+            required: ['projectPath', 'scenePath', 'parentPath', 'texture'],
+          },
+        },
+        {
+          name: 'add_area2d',
+          description: 'Add an Area2D + nested CollisionShape2D — hitboxes, hurtboxes, triggers, pickups (with collision layer/mask).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              parentPath: { type: 'string' },
+              shape: { type: 'string', enum: ['rectangle', 'circle', 'capsule'] },
+              size: { type: 'array' },
+              radius: { type: 'number' },
+              height: { type: 'number' },
+              position: { type: 'array' },
+              collisionLayer: { type: 'number' },
+              collisionMask: { type: 'number' },
+              name: { type: 'string' },
+            },
+            required: ['projectPath', 'scenePath', 'parentPath'],
+          },
+        },
+        {
+          name: 'add_particles',
+          description: 'Add a GPUParticles2D + ParticleProcessMaterial — cheap juice (bursts, trails, dust).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: { type: 'string' },
+              scenePath: { type: 'string' },
+              parentPath: { type: 'string' },
+              amount: { type: 'number' },
+              lifetime: { type: 'number' },
+              texture: { type: 'string' },
+              gravity: { type: 'number' },
+              spread: { type: 'number' },
+              velocity: { type: 'number' },
+              oneShot: { type: 'boolean' },
+              explosiveness: { type: 'number' },
+              name: { type: 'string' },
+            },
+            required: ['projectPath', 'scenePath', 'parentPath'],
+          },
+        },
+        {
           name: 'load_sprite',
           description: 'Load a sprite into a Sprite2D node',
           inputSchema: {
@@ -948,6 +1095,22 @@ class GodotServer {
           return await this.handleCreateScene(request.params.arguments);
         case 'add_node':
           return await this.handleAddNode(request.params.arguments);
+        case 'add_animation':
+          return await this.handleAuthoringOp('add_animation', request.params.arguments, ['animationName']);
+        case 'add_collision_shape':
+          return await this.handleAuthoringOp('add_collision_shape', request.params.arguments, ['parentPath']);
+        case 'set_camera_limits':
+          return await this.handleAuthoringOp('set_camera_limits', request.params.arguments, []);
+        case 'connect_signal':
+          return await this.handleAuthoringOp('connect_signal', request.params.arguments, ['fromPath', 'signal', 'toPath', 'method']);
+        case 'add_animated_sprite':
+          return await this.handleAuthoringOp('add_animated_sprite', request.params.arguments, ['parentPath', 'texture']);
+        case 'paint_tilemap':
+          return await this.handleAuthoringOp('paint_tilemap', request.params.arguments, ['parentPath', 'texture']);
+        case 'add_area2d':
+          return await this.handleAuthoringOp('add_area2d', request.params.arguments, ['parentPath']);
+        case 'add_particles':
+          return await this.handleAuthoringOp('add_particles', request.params.arguments, ['parentPath']);
         case 'load_sprite':
           return await this.handleLoadSprite(request.params.arguments);
         case 'export_mesh_library':
@@ -1577,6 +1740,50 @@ class GodotServer {
   /**
    * Handle the add_node tool
    */
+  // Generic handler for the headless AUTHORING-LAYER ops (animation, collision,
+  // camera limits, signals, animated sprites, tilemaps, areas, particles). Each
+  // validates the project + scene, then drives godot_operations.gd via executeOperation.
+  private async handleAuthoringOp(operation: string, args: any, required: string[]) {
+    args = this.normalizeParameters(args);
+    const need = ['projectPath', 'scenePath', ...required];
+    for (const key of need) {
+      if (args[key] === undefined || args[key] === null || args[key] === '') {
+        return this.createErrorResponse(`Missing required parameter: ${key}`, [
+          `Provide: ${need.join(', ')}`,
+        ]);
+      }
+    }
+    if (!this.validatePath(args.projectPath) || !this.validatePath(args.scenePath)) {
+      return this.createErrorResponse('Invalid path', [
+        'Provide valid paths without ".." or other unsafe characters',
+      ]);
+    }
+    if (!existsSync(join(args.projectPath, 'project.godot'))) {
+      return this.createErrorResponse(`Not a valid Godot project: ${args.projectPath}`, [
+        'The path must contain a project.godot file',
+      ]);
+    }
+    if (!existsSync(join(args.projectPath, args.scenePath))) {
+      return this.createErrorResponse(`Scene file does not exist: ${args.scenePath}`, [
+        'Create it with create_scene first',
+      ]);
+    }
+    const params: any = { ...args };
+    delete params.projectPath;
+    try {
+      const { stdout, stderr } = await this.executeOperation(operation, params, args.projectPath);
+      if (stderr && /Failed to|not found|does not exist|has no signal/.test(stderr)) {
+        return this.createErrorResponse(`${operation} failed: ${stderr.trim().slice(-400)}`, [
+          'Check the node paths (parentPath/fromPath/toPath) exist in the scene',
+          'Verify any referenced texture path is a res:// resource',
+        ]);
+      }
+      return { content: [{ type: 'text', text: `${operation} completed.\n${stdout}`.trim() }] };
+    } catch (e: any) {
+      return this.createErrorResponse(`${operation} error: ${e?.message ?? String(e)}`, []);
+    }
+  }
+
   private async handleAddNode(args: any) {
     // Normalize parameters to camelCase
     args = this.normalizeParameters(args);

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -55,11 +55,21 @@ func _init():
         log_error("Failed to parse JSON parameters: " + params_json)
         log_error("JSON Error: " + json.get_error_message() + " at line " + str(json.get_error_line()))
         quit(1)
-    
+        return
+
+    # Resident op-server — checked BEFORE the empty-params guard (its params are legitimately
+    # {}). Stays warm and serves ops over TCP so N ops cost ONE Godot boot (no reboot per op).
+    # Blocks until the client disconnects / shuts down.
+    if operation == "__serve":
+        _serve(params if params != null else {})
+        quit()
+        return
+
     if not params:
         log_error("Failed to parse JSON parameters: " + params_json)
         quit(1)
-    
+        return
+
     log_info("Executing operation: " + operation)
 
     _dispatch(operation, params)
@@ -1330,6 +1340,92 @@ func _to_snake(s):
         else:
             r += c
     return r
+
+# Resident op-server. Opens a TCP listener on an ephemeral port, prints it (so the MCP
+# server can connect), then serves newline-delimited JSON requests { id, op, params } ->
+# { id, ok, result|error } by replaying the SAME _dispatch handlers — no reboot per op.
+# One request at a time (the TS side serializes). A handler that hits a hard error still
+# quit()s the process; the TS side detects the exit and restarts the resident.
+func _serve(params):
+    var server = TCPServer.new()
+    var err = server.listen(0)
+    if err != OK:
+        printerr("op-server: listen failed: " + str(err))
+        return
+    var port = server.get_local_port()
+    # This exact marker is how the MCP server learns the port. Keep it stable.
+    print("LEON_OP_SERVER_PORT " + str(port))
+
+    # Wait (bounded) for the MCP server to connect.
+    var peer = null
+    var waited = 0
+    while peer == null:
+        if server.is_connection_available():
+            peer = server.take_connection()
+        else:
+            OS.delay_msec(5)
+            waited += 5
+            if waited > 30000:
+                printerr("op-server: no client connected within 30s")
+                server.stop()
+                return
+    peer.set_no_delay(true)
+    print("LEON_OP_SERVER_READY")
+
+    var buf = ""
+    while true:
+        peer.poll()
+        if peer.get_status() != StreamPeerTCP.STATUS_CONNECTED:
+            break
+        var avail = peer.get_available_bytes()
+        if avail > 0:
+            buf += peer.get_utf8_string(avail)
+            while buf.find("\n") != -1:
+                var idx = buf.find("\n")
+                var line = buf.substr(0, idx)
+                buf = buf.substr(idx + 1)
+                if line.strip_edges() != "":
+                    _handle_request(peer, line)
+        else:
+            OS.delay_msec(3)
+    server.stop()
+
+func _handle_request(peer, line):
+    var json = JSON.new()
+    if json.parse(line) != OK:
+        _reply(peer, {"id": null, "ok": false, "error": "bad json"})
+        return
+    var req = json.get_data()
+    if not (req is Dictionary):
+        _reply(peer, {"id": null, "ok": false, "error": "request must be an object"})
+        return
+    var id = req.get("id", null)
+    var op = str(req.get("op", ""))
+    if op == "__ping":
+        _reply(peer, {"id": id, "ok": true, "result": "pong"})
+        return
+    if op == "__shutdown":
+        _reply(peer, {"id": id, "ok": true, "result": "bye"})
+        _reply_flush(peer)
+        quit()
+        return
+    if op == "__serve" or op == "":
+        _reply(peer, {"id": id, "ok": false, "error": "invalid op"})
+        return
+    var op_params = _snakeify(req.get("params", {}))
+    # A failing handler prints the error + quit()s the process; the client then sees the
+    # socket close and treats this request as failed. On success it prints to stdout and
+    # we ack over TCP (mutating ops persist their own .tscn via _authoring_save).
+    _dispatch(op, op_params)
+    _reply(peer, {"id": id, "ok": true})
+
+func _reply(peer, obj):
+    var data = (JSON.stringify(obj) + "\n").to_utf8_buffer()
+    peer.put_data(data)
+
+func _reply_flush(peer):
+    # best-effort: make sure the reply bytes go out before we quit
+    peer.poll()
 
 func _authoring_load(params):
     # In a batch, every op shares the ONE scene loaded by batch_author — don't reload.

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -4,6 +4,12 @@ extends SceneTree
 # Debug mode flag
 var debug_mode = false
 
+# batch_author state — when active, the authoring ops share ONE loaded scene and defer
+# the save, so N ops cost ONE Godot boot instead of N. See batch_author() + _dispatch().
+var _batch_active = false
+var _batch_root = null
+var _batch_abs = ""
+
 func _init():
     var args = OS.get_cmdline_args()
     
@@ -55,8 +61,17 @@ func _init():
         quit(1)
     
     log_info("Executing operation: " + operation)
-    
+
+    _dispatch(operation, params)
+
+    quit()
+
+# Route an operation name to its handler. Factored out of _init so batch_author can
+# replay the same handlers against one shared, already-loaded scene.
+func _dispatch(operation, params):
     match operation:
+        "batch_author":
+            batch_author(params)
         "create_scene":
             create_scene(params)
         "add_node":
@@ -104,8 +119,6 @@ func _init():
         _:
             log_error("Unknown operation: " + operation)
             quit(1)
-    
-    quit()
 
 # Logging functions
 func log_debug(message):
@@ -1221,7 +1234,107 @@ func save_scene(params):
 # scene -> modify via the engine's own APIs -> pack -> save.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# Apply an ORDERED list of authoring ops against ONE scene loaded ONCE, saving ONCE at the
+# end — so a scene authored with K ops costs a single Godot boot, not K. On any op's internal
+# failure the op quits the process before the final save, so the .tscn on disk is left
+# unchanged (no partial writes). params: { scene_path, ops:[{op, ...opParams}] }.
+func batch_author(params):
+    if not params.has("scene_path"):
+        printerr("batch_author requires scene_path")
+        quit(1)
+        return
+    var full = str(params.scene_path)
+    if not full.begins_with("res://"):
+        full = "res://" + full
+    var abs_path = ProjectSettings.globalize_path(full)
+    if not FileAccess.file_exists(abs_path):
+        printerr("Scene file does not exist at: " + abs_path)
+        quit(1)
+        return
+    var scene = load(full)
+    if not scene:
+        printerr("Failed to load scene: " + full)
+        quit(1)
+        return
+    var ops = params.get("ops", [])
+    if not (ops is Array) or ops.size() == 0:
+        printerr("batch_author requires a non-empty 'ops' array")
+        quit(1)
+        return
+
+    _batch_root = scene.instantiate()
+    _batch_abs = abs_path
+    _batch_active = true
+
+    var applied = 0
+    for i in range(ops.size()):
+        var raw = ops[i]
+        if not (raw is Dictionary) or not raw.has("op"):
+            _batch_active = false
+            printerr("batch_author: op #" + str(i) + " must be an object with an 'op' field")
+            quit(1)
+            return
+        # The TS camel->snake converter doesn't recurse into arrays, so batched op entries
+        # arrive camelCase — normalize each entry's keys here so the handlers find them.
+        var entry = _snakeify(raw)
+        var op_name = str(entry.op)
+        if op_name == "batch_author":
+            _batch_active = false
+            printerr("batch_author cannot be nested")
+            quit(1)
+            return
+        log_info("[batch] op " + str(i + 1) + "/" + str(ops.size()) + ": " + op_name)
+        # A failing handler calls quit() itself -> process ends before the save below,
+        # leaving the scene file untouched.
+        _dispatch(op_name, entry)
+        applied += 1
+
+    # All ops applied against the in-memory tree — pack + save exactly once.
+    _batch_active = false
+    var packed = PackedScene.new()
+    var result = packed.pack(_batch_root)
+    if result != OK:
+        printerr("batch_author: failed to pack scene: " + str(result))
+        quit(1)
+        return
+    var err = ResourceSaver.save(packed, _batch_abs)
+    if err != OK:
+        printerr("batch_author: failed to save scene: " + str(err))
+        quit(1)
+        return
+    print("batch_author applied " + str(applied) + " op(s) to " + str(params.scene_path))
+
+# Recursively convert Dictionary keys from camelCase to snake_case (and descend into
+# nested arrays/dicts), so batched op params match what the handlers read.
+func _snakeify(v):
+    if v is Dictionary:
+        var out = {}
+        for k in v.keys():
+            out[_to_snake(str(k))] = _snakeify(v[k])
+        return out
+    elif v is Array:
+        var arr = []
+        for e in v:
+            arr.append(_snakeify(e))
+        return arr
+    return v
+
+func _to_snake(s):
+    var r = ""
+    for i in range(s.length()):
+        var c = s[i]
+        if c >= "A" and c <= "Z":
+            if i > 0:
+                r += "_"
+            r += c.to_lower()
+        else:
+            r += c
+    return r
+
 func _authoring_load(params):
+    # In a batch, every op shares the ONE scene loaded by batch_author — don't reload.
+    if _batch_active:
+        return {"root": _batch_root, "abs": _batch_abs}
     var full = params.scene_path
     if not full.begins_with("res://"):
         full = "res://" + full
@@ -1247,6 +1360,11 @@ func _authoring_find(root, path):
     return n
 
 func _authoring_save(root, abs_path, msg):
+    # In a batch, defer the real save — batch_author packs + saves ONCE at the end, so a
+    # mid-batch failure (which quits) leaves the .tscn on disk untouched. Just log progress.
+    if _batch_active:
+        print("[batch] " + msg)
+        return
     var packed = PackedScene.new()
     var result = packed.pack(root)
     if result != OK:

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -71,6 +71,14 @@ func _init():
             get_uid(params)
         "resave_resources":
             resave_resources(params)
+        "add_animation":
+            add_animation(params)
+        "add_collision_shape":
+            add_collision_shape(params)
+        "set_camera_limits":
+            set_camera_limits(params)
+        "connect_signal":
+            connect_signal(params)
         _:
             log_error("Unknown operation: " + operation)
             quit(1)
@@ -1184,3 +1192,189 @@ func save_scene(params):
             printerr("Failed to save scene: " + str(error))
     else:
         printerr("Failed to pack scene: " + str(result))
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AUTHORING LAYER (Studio Leon) — drive Godot's real node systems headlessly, so
+# agents stop hand-rolling movement/animation on a bare canvas. Each op: load the
+# scene -> modify via the engine's own APIs -> pack -> save.
+# ─────────────────────────────────────────────────────────────────────────────
+
+func _authoring_load(params):
+    var full = params.scene_path
+    if not full.begins_with("res://"):
+        full = "res://" + full
+    var abs_path = ProjectSettings.globalize_path(full)
+    if not FileAccess.file_exists(abs_path):
+        printerr("Scene file does not exist at: " + abs_path)
+        quit(1)
+        return null
+    var scene = load(full)
+    if not scene:
+        printerr("Failed to load scene: " + full)
+        quit(1)
+        return null
+    return {"root": scene.instantiate(), "abs": abs_path}
+
+func _authoring_find(root, path):
+    if path == null or path == "" or path == "root":
+        return root
+    var p = str(path).replace("root/", "")
+    var n = root.get_node_or_null(p)
+    if n == null:
+        printerr("Node not found: " + str(path))
+    return n
+
+func _authoring_save(root, abs_path, msg):
+    var packed = PackedScene.new()
+    var result = packed.pack(root)
+    if result != OK:
+        printerr("Failed to pack scene: " + str(result))
+        quit(1)
+        return
+    var err = ResourceSaver.save(packed, abs_path)
+    if err != OK:
+        printerr("Failed to save scene: " + str(err))
+        quit(1)
+        return
+    print(msg)
+
+# Add an AnimationPlayer (if needed) + a value-track Animation built from keys.
+# params: scene_path, animation_name, player_parent?, player_path?, length?, loop?,
+#   tracks:[{path:"NodeName:property", keys:[{time,value}], interp?:"nearest"}]
+func add_animation(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var player = null
+    if params.has("player_path"):
+        player = _authoring_find(root, params.player_path)
+    var player_parent = _authoring_find(root, params.get("player_parent", "root"))
+    if player_parent == null:
+        quit(1)
+        return
+    if player == null:
+        player = player_parent.get_node_or_null("AnimationPlayer")
+    if player == null:
+        player = AnimationPlayer.new()
+        player.name = "AnimationPlayer"
+        player_parent.add_child(player)
+        player.owner = root
+    var anim = Animation.new()
+    anim.length = float(params.get("length", 1.0))
+    if bool(params.get("loop", true)):
+        anim.loop_mode = Animation.LOOP_LINEAR
+    else:
+        anim.loop_mode = Animation.LOOP_NONE
+    for track in params.get("tracks", []):
+        var ti = anim.add_track(Animation.TYPE_VALUE)
+        anim.track_set_path(ti, NodePath(track.path))
+        if track.get("interp", "") == "nearest":
+            anim.track_set_interpolation_type(ti, Animation.INTERPOLATION_NEAREST)
+        for key in track.get("keys", []):
+            anim.track_insert_key(ti, float(key.time), key.value)
+    var lib
+    if player.has_animation_library(""):
+        lib = player.get_animation_library("")
+    else:
+        lib = AnimationLibrary.new()
+        player.add_animation_library("", lib)
+    var an = params.get("animation_name", "anim")
+    if lib.has_animation(an):
+        lib.remove_animation(an)
+    lib.add_animation(an, anim)
+    _authoring_save(root, ctx.abs, "Animation '" + str(an) + "' added to " + str(player.name))
+
+# Add a CollisionShape2D with a real shape to a body — fixes floating / no-collision.
+# params: scene_path, parent_path (the body), shape:"rectangle"|"circle"|"capsule",
+#   size:[w,h] | radius | height, position?:[x,y], name?
+func add_collision_shape(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var parent = _authoring_find(root, params.get("parent_path", "root"))
+    if parent == null:
+        quit(1)
+        return
+    var cs = CollisionShape2D.new()
+    cs.name = params.get("name", "CollisionShape2D")
+    var kind = params.get("shape", "rectangle")
+    var shape
+    if kind == "circle":
+        shape = CircleShape2D.new()
+        shape.radius = float(params.get("radius", 16))
+    elif kind == "capsule":
+        shape = CapsuleShape2D.new()
+        shape.radius = float(params.get("radius", 12))
+        shape.height = float(params.get("height", 40))
+    else:
+        shape = RectangleShape2D.new()
+        var sz = params.get("size", [32, 32])
+        shape.size = Vector2(float(sz[0]), float(sz[1]))
+    cs.shape = shape
+    if params.has("position"):
+        var pos = params.position
+        cs.position = Vector2(float(pos[0]), float(pos[1]))
+    parent.add_child(cs)
+    cs.owner = root
+    _authoring_save(root, ctx.abs, "CollisionShape2D (" + str(kind) + ") added to " + str(parent.name))
+
+# Set Camera2D limits (clamp to the map), creating the camera if needed.
+# params: scene_path, camera_path? | camera_parent?, limits:{left,top,right,bottom}, smoothing?
+func set_camera_limits(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var cam = null
+    if params.has("camera_path"):
+        cam = _authoring_find(root, params.camera_path)
+    if cam == null:
+        var parent = _authoring_find(root, params.get("camera_parent", "root"))
+        if parent == null:
+            quit(1)
+            return
+        cam = parent.get_node_or_null("Camera2D")
+        if cam == null:
+            cam = Camera2D.new()
+            cam.name = "Camera2D"
+            parent.add_child(cam)
+            cam.owner = root
+    var lim = params.get("limits", {})
+    if lim.has("left"):
+        cam.limit_left = int(lim.left)
+    if lim.has("top"):
+        cam.limit_top = int(lim.top)
+    if lim.has("right"):
+        cam.limit_right = int(lim.right)
+    if lim.has("bottom"):
+        cam.limit_bottom = int(lim.bottom)
+    if params.has("smoothing"):
+        cam.position_smoothing_enabled = true
+        cam.position_smoothing_speed = float(params.smoothing)
+    _authoring_save(root, ctx.abs, "Camera2D limits set on " + str(cam.name))
+
+# Persistently connect a signal (serialized into the scene) — wire, don't hand-poll.
+# params: scene_path, from_path, signal, to_path, method
+func connect_signal(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var from_node = _authoring_find(root, params.from_path)
+    var to_node = _authoring_find(root, params.to_path)
+    if from_node == null or to_node == null:
+        quit(1)
+        return
+    var sig = params["signal"]
+    if not from_node.has_signal(sig):
+        printerr("Node has no signal: " + str(sig))
+        quit(1)
+        return
+    var err = from_node.connect(sig, Callable(to_node, params.method), CONNECT_PERSIST)
+    if err != OK:
+        printerr("Failed to connect signal: " + str(err))
+        quit(1)
+        return
+    _authoring_save(root, ctx.abs, "Connected " + str(from_node.name) + "." + str(sig) + " -> " + str(to_node.name) + "." + str(params.method))

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -79,6 +79,14 @@ func _init():
             set_camera_limits(params)
         "connect_signal":
             connect_signal(params)
+        "add_animated_sprite":
+            add_animated_sprite(params)
+        "paint_tilemap":
+            paint_tilemap(params)
+        "add_area2d":
+            add_area2d(params)
+        "add_particles":
+            add_particles(params)
         _:
             log_error("Unknown operation: " + operation)
             quit(1)
@@ -1378,3 +1386,171 @@ func connect_signal(params):
         quit(1)
         return
     _authoring_save(root, ctx.abs, "Connected " + str(from_node.name) + "." + str(sig) + " -> " + str(to_node.name) + "." + str(params.method))
+
+# ── AUTHORING LAYER batch 2 — animated sprites, tilemaps, areas, particles ──────
+
+func _make_shape(params):
+    var kind = params.get("shape", "rectangle")
+    var shape
+    if kind == "circle":
+        shape = CircleShape2D.new()
+        shape.radius = float(params.get("radius", 16))
+    elif kind == "capsule":
+        shape = CapsuleShape2D.new()
+        shape.radius = float(params.get("radius", 12))
+        shape.height = float(params.get("height", 40))
+    else:
+        shape = RectangleShape2D.new()
+        var sz = params.get("size", [32, 32])
+        shape.size = Vector2(float(sz[0]), float(sz[1]))
+    return shape
+
+# AnimatedSprite2D + SpriteFrames built from a sprite sheet (grid of frames).
+# params: scene_path, parent_path, name?, texture (res:// sheet), frame_width, frame_height,
+#   animations:[{name, frames:[frame_index,...], fps?, loop?}], autoplay?
+func add_animated_sprite(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var parent = _authoring_find(root, params.get("parent_path", "root"))
+    if parent == null:
+        quit(1)
+        return
+    var tex = load(params.texture)
+    if tex == null:
+        printerr("Texture not found: " + str(params.texture))
+        quit(1)
+        return
+    var fw = int(params.get("frame_width", 16))
+    var fh = int(params.get("frame_height", 16))
+    var cols = int(tex.get_width() / fw)
+    if cols < 1:
+        cols = 1
+    var sf = SpriteFrames.new()
+    if sf.has_animation("default"):
+        sf.remove_animation("default")
+    for a in params.get("animations", []):
+        var aname = a.name
+        if not sf.has_animation(aname):
+            sf.add_animation(aname)
+        sf.set_animation_speed(aname, float(a.get("fps", 8)))
+        sf.set_animation_loop(aname, bool(a.get("loop", true)))
+        for idx in a.get("frames", []):
+            var at = AtlasTexture.new()
+            at.atlas = tex
+            var fx = (int(idx) % cols) * fw
+            var fy = int(int(idx) / cols) * fh
+            at.region = Rect2(fx, fy, fw, fh)
+            sf.add_frame(aname, at)
+    var spr = AnimatedSprite2D.new()
+    spr.name = params.get("name", "AnimatedSprite2D")
+    spr.sprite_frames = sf
+    if params.has("autoplay"):
+        spr.autoplay = params.autoplay
+    parent.add_child(spr)
+    spr.owner = root
+    _authoring_save(root, ctx.abs, "AnimatedSprite2D added to " + str(parent.name))
+
+# A TileMapLayer with a TileSet built from an atlas texture, then painted cells.
+# params: scene_path, parent_path, name?, texture (res:// atlas), tile_size,
+#   cells:[{x,y,atlas_x,atlas_y}]
+func paint_tilemap(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var parent = _authoring_find(root, params.get("parent_path", "root"))
+    if parent == null:
+        quit(1)
+        return
+    var tex = load(params.texture)
+    if tex == null:
+        printerr("Texture not found: " + str(params.texture))
+        quit(1)
+        return
+    var tile = int(params.get("tile_size", 16))
+    var ts = TileSet.new()
+    ts.tile_size = Vector2i(tile, tile)
+    var src = TileSetAtlasSource.new()
+    src.texture = tex
+    src.texture_region_size = Vector2i(tile, tile)
+    var cols = int(tex.get_width() / tile)
+    var rows = int(tex.get_height() / tile)
+    for ty in rows:
+        for tx in cols:
+            src.create_tile(Vector2i(tx, ty))
+    var src_id = ts.add_source(src)
+    var layer = TileMapLayer.new()
+    layer.name = params.get("name", "TileMapLayer")
+    layer.tile_set = ts
+    for cell in params.get("cells", []):
+        layer.set_cell(Vector2i(int(cell.x), int(cell.y)), src_id, Vector2i(int(cell.atlas_x), int(cell.atlas_y)))
+    parent.add_child(layer)
+    layer.owner = root
+    _authoring_save(root, ctx.abs, "TileMapLayer painted (" + str(params.get("cells", []).size()) + " cells)")
+
+# An Area2D + CollisionShape2D — hitboxes/hurtboxes/triggers/pickups.
+# params: scene_path, parent_path, name?, shape/size/radius/height, position?,
+#   collision_layer?, collision_mask?
+func add_area2d(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var parent = _authoring_find(root, params.get("parent_path", "root"))
+    if parent == null:
+        quit(1)
+        return
+    var area = Area2D.new()
+    area.name = params.get("name", "Area2D")
+    if params.has("collision_layer"):
+        area.collision_layer = int(params.collision_layer)
+    if params.has("collision_mask"):
+        area.collision_mask = int(params.collision_mask)
+    var cs = CollisionShape2D.new()
+    cs.shape = _make_shape(params)
+    if params.has("position"):
+        var pos = params.position
+        cs.position = Vector2(float(pos[0]), float(pos[1]))
+    parent.add_child(area)
+    area.owner = root
+    area.add_child(cs)
+    cs.owner = root
+    _authoring_save(root, ctx.abs, "Area2D added to " + str(parent.name))
+
+# GPUParticles2D + ParticleProcessMaterial — cheap juice (bursts, trails, dust).
+# params: scene_path, parent_path, name?, amount?, lifetime?, texture?, gravity?,
+#   spread?, velocity?, one_shot?, explosiveness?
+func add_particles(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var parent = _authoring_find(root, params.get("parent_path", "root"))
+    if parent == null:
+        quit(1)
+        return
+    var p = GPUParticles2D.new()
+    p.name = params.get("name", "GPUParticles2D")
+    p.amount = int(params.get("amount", 16))
+    p.lifetime = float(params.get("lifetime", 1.0))
+    if params.has("one_shot"):
+        p.one_shot = bool(params.one_shot)
+    if params.has("explosiveness"):
+        p.explosiveness = float(params.explosiveness)
+    if params.has("texture"):
+        var tex = load(params.texture)
+        if tex != null:
+            p.texture = tex
+    var mat = ParticleProcessMaterial.new()
+    mat.gravity = Vector3(0, float(params.get("gravity", 98)), 0)
+    if params.has("spread"):
+        mat.spread = float(params.spread)
+    if params.has("velocity"):
+        mat.initial_velocity_min = float(params.velocity)
+        mat.initial_velocity_max = float(params.velocity)
+    p.process_material = mat
+    parent.add_child(p)
+    p.owner = root
+    _authoring_save(root, ctx.abs, "GPUParticles2D added to " + str(parent.name))

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -1485,7 +1485,11 @@ func paint_tilemap(params):
     layer.name = params.get("name", "TileMapLayer")
     layer.tile_set = ts
     for cell in params.get("cells", []):
-        layer.set_cell(Vector2i(int(cell.x), int(cell.y)), src_id, Vector2i(int(cell.atlas_x), int(cell.atlas_y)))
+        # tolerate both snake_case and camelCase for the atlas coords (array items
+        # aren't key-converted by the MCP layer)
+        var ax = cell.get("atlas_x", cell.get("atlasX", 0))
+        var ay = cell.get("atlas_y", cell.get("atlasY", 0))
+        layer.set_cell(Vector2i(int(cell.x), int(cell.y)), src_id, Vector2i(int(ax), int(ay)))
     parent.add_child(layer)
     layer.owner = root
     _authoring_save(root, ctx.abs, "TileMapLayer painted (" + str(params.get("cells", []).size()) + " cells)")

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -87,6 +87,20 @@ func _init():
             add_area2d(params)
         "add_particles":
             add_particles(params)
+        "attach_script":
+            attach_script(params)
+        "set_node_property":
+            set_node_property(params)
+        "remove_node":
+            remove_node(params)
+        "instance_scene":
+            instance_scene(params)
+        "get_scene_tree":
+            get_scene_tree(params)
+        "add_input_action":
+            add_input_action(params)
+        "set_project_setting":
+            set_project_setting(params)
         _:
             log_error("Unknown operation: " + operation)
             quit(1)
@@ -1558,3 +1572,166 @@ func add_particles(params):
     parent.add_child(p)
     p.owner = root
     _authoring_save(root, ctx.abs, "GPUParticles2D added to " + str(parent.name))
+
+# ── AUTHORING LAYER batch 3 — behavior, input, project config, composition, edit ─
+
+# Attach an existing GDScript (write the .gd first) to a node in the scene.
+# params: scene_path, node_path, script_path (res://...)
+func attach_script(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var node = _authoring_find(root, params.node_path)
+    if node == null:
+        quit(1)
+        return
+    var sp = params.script_path
+    if not sp.begins_with("res://"):
+        sp = "res://" + sp
+    var scr = load(sp)
+    if scr == null:
+        printerr("Script not found: " + str(sp))
+        quit(1)
+        return
+    node.set_script(scr)
+    _authoring_save(root, ctx.abs, "Script " + str(sp) + " attached to " + str(node.name))
+
+# Set properties on an EXISTING node (add_node sets them at creation; use this to tweak).
+# params: scene_path, node_path, properties:{...}   (res:// values are loaded)
+func set_node_property(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var node = _authoring_find(root, params.node_path)
+    if node == null:
+        quit(1)
+        return
+    for property in params.get("properties", {}):
+        var value = params.properties[property]
+        if typeof(value) == TYPE_STRING and value.begins_with("res://"):
+            value = load(value)
+        node.set(property, value)
+    _authoring_save(root, ctx.abs, "Properties set on " + str(node.name))
+
+# Remove a node from the scene.
+# params: scene_path, node_path
+func remove_node(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var node = _authoring_find(root, params.node_path)
+    if node == null:
+        quit(1)
+        return
+    if node == root:
+        printerr("Cannot remove the scene root")
+        quit(1)
+        return
+    var parent = node.get_parent()
+    parent.remove_child(node)
+    node.free()
+    _authoring_save(root, ctx.abs, "Removed node " + str(params.node_path))
+
+# Instance a sub-scene (a PackedScene / prefab) as a child — the Godot way to compose.
+# params: scene_path, sub_scene (res:// .tscn), parent_path?, name?, position?:[x,y]
+func instance_scene(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    var root = ctx.root
+    var parent = _authoring_find(root, params.get("parent_path", "root"))
+    if parent == null:
+        quit(1)
+        return
+    var sub = params.sub_scene
+    if not sub.begins_with("res://"):
+        sub = "res://" + sub
+    var packed = load(sub)
+    if packed == null:
+        printerr("Sub-scene not found: " + str(sub))
+        quit(1)
+        return
+    var inst = packed.instantiate()
+    if params.has("name"):
+        inst.name = params.name
+    if params.has("position") and inst is Node2D:
+        var pos = params.position
+        inst.position = Vector2(float(pos[0]), float(pos[1]))
+    parent.add_child(inst)
+    inst.owner = root
+    _authoring_save(root, ctx.abs, "Instanced " + str(sub) + " under " + str(parent.name))
+
+# Print the scene tree (name : type per node) to stdout — inspection for the agent.
+# params: scene_path
+func get_scene_tree(params):
+    var ctx = _authoring_load(params)
+    if ctx == null:
+        return
+    _print_tree(ctx.root, 0)
+    print("SCENE TREE OK")
+
+func _print_tree(node, depth):
+    var pad = ""
+    for i in depth:
+        pad += "  "
+    var scr = ""
+    if node.get_script() != null:
+        scr = " [script]"
+    print(pad + str(node.name) + " : " + node.get_class() + scr)
+    for child in node.get_children():
+        _print_tree(child, depth + 1)
+
+# ── PROJECT-LEVEL ops (operate on project.godot, no scene) ──────────────────────
+
+# Define an InputMap action (so Input.is_action_pressed works — the missing-binding fix).
+# params: action, deadzone?, events:[{type:"key"|"joy_button"|"mouse_button", key?:"X", button?:0}]
+func add_input_action(params):
+    var action = "input/" + str(params.action)
+    var events = []
+    for e in params.get("events", []):
+        var t = e.get("type", "key")
+        if t == "key":
+            var ev = InputEventKey.new()
+            var code = OS.find_keycode_from_string(str(e.get("key", "")))
+            ev.physical_keycode = code
+            ev.keycode = code
+            events.append(ev)
+        elif t == "joy_button":
+            var jb = InputEventJoypadButton.new()
+            jb.button_index = int(e.get("button", 0))
+            events.append(jb)
+        elif t == "mouse_button":
+            var mb = InputEventMouseButton.new()
+            mb.button_index = int(e.get("button", 1))
+            events.append(mb)
+    var entry = {"deadzone": float(params.get("deadzone", 0.5)), "events": events}
+    ProjectSettings.set_setting(action, entry)
+    var err = ProjectSettings.save()
+    if err != OK:
+        printerr("Failed to save project settings: " + str(err))
+        quit(1)
+        return
+    print("Input action '" + str(params.action) + "' defined with " + str(events.size()) + " event(s)")
+
+# Set arbitrary project settings (main scene, window size, stretch, physics tick...).
+# params: settings:{ "application/run/main_scene":"res://main.tscn",
+#   "display/window/size/viewport_width":1280, "display/window/stretch/mode":"canvas_items", ... }
+func set_project_setting(params):
+    var settings = params.get("settings", {})
+    var count = 0
+    for key in settings:
+        var value = settings[key]
+        # main_scene wants a res:// path string
+        if typeof(value) == TYPE_STRING and (key as String).ends_with("main_scene") and not value.begins_with("res://"):
+            value = "res://" + value
+        ProjectSettings.set_setting(key, value)
+        count += 1
+    var err = ProjectSettings.save()
+    if err != OK:
+        printerr("Failed to save project settings: " + str(err))
+        quit(1)
+        return
+    print("Set " + str(count) + " project setting(s)")

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -1546,8 +1546,7 @@ func add_collision_shape(params):
         shape.height = float(params.get("height", 40))
     else:
         shape = RectangleShape2D.new()
-        var sz = params.get("size", [32, 32])
-        shape.size = Vector2(float(sz[0]), float(sz[1]))
+        shape.size = _to_size(params.get("size", null))
     cs.shape = shape
     if params.has("position"):
         var pos = params.position
@@ -1617,6 +1616,21 @@ func connect_signal(params):
 
 # ── AUTHORING LAYER batch 2 — animated sprites, tilemaps, areas, particles ──────
 
+# Robustly read a 2D size from agent-supplied params. Callers pass it as a dict {x,y}
+# (or {w,h}), an array [w,h], a single number (square), or omit it (default). The old code
+# assumed an array and crashed on the dict form ("Invalid access to key '0'").
+func _to_size(v, def_w := 32.0, def_h := 32.0) -> Vector2:
+    if v is Dictionary:
+        return Vector2(float(v.get("x", v.get("w", def_w))), float(v.get("y", v.get("h", def_h))))
+    if v is Array:
+        if v.size() >= 2:
+            return Vector2(float(v[0]), float(v[1]))
+        if v.size() == 1:
+            return Vector2(float(v[0]), float(v[0]))
+    if v is float or v is int:
+        return Vector2(float(v), float(v))
+    return Vector2(def_w, def_h)
+
 func _make_shape(params):
     var kind = params.get("shape", "rectangle")
     var shape
@@ -1629,8 +1643,7 @@ func _make_shape(params):
         shape.height = float(params.get("height", 40))
     else:
         shape = RectangleShape2D.new()
-        var sz = params.get("size", [32, 32])
-        shape.size = Vector2(float(sz[0]), float(sz[1]))
+        shape.size = _to_size(params.get("size", null))
     return shape
 
 # AnimatedSprite2D + SpriteFrames built from a sprite sheet (grid of frames).


### PR DESCRIPTION
## What this adds

A **headless authoring layer** on top of the existing CLI + bundled-`godot_operations.gd` pattern — **15 new operations** (and matching MCP tools) so an agent or CI job can build a *real* Godot game **without the editor GUI**, using Godot's actual node systems instead of hand-rolling everything in code.

The motivation: when an LLM agent drives Godot with only `create_scene` / `add_node` / `load_sprite`, it tends to fall back to hand-rolled movement + custom `_draw`, because the systems it needs (animation, collision, tilemaps, input, etc.) are normally authored in the editor GUI. These ops expose those systems headlessly.

### New operations

**Scene systems**
- `add_animation` — `AnimationPlayer` + a keyframed value-track `Animation`
- `add_collision_shape` — `CollisionShape2D` + shape (rectangle/circle/capsule) on a body
- `add_animated_sprite` — `AnimatedSprite2D` + `SpriteFrames` from a sprite-sheet grid
- `paint_tilemap` — `TileMapLayer` + `TileSet` from an atlas, cells painted
- `add_area2d` — `Area2D` + nested `CollisionShape2D` (layers/mask)
- `add_particles` — `GPUParticles2D` + `ParticleProcessMaterial`
- `set_camera_limits` — `Camera2D` clamped to the map
- `connect_signal` — a persistent (`CONNECT_PERSIST`) signal connection, serialized into the scene

**Game-building**
- `attach_script` — attach a `.gd` to a node
- `instance_scene` — instance a sub-scene / prefab as a child
- `set_node_property`, `remove_node`, `get_scene_tree` — edit + inspect
- `add_input_action` — define an `InputMap` action in `project.godot`
- `set_project_setting` — main scene, window size, stretch mode, physics, etc.

## How it's built

- New ops in `src/scripts/godot_operations.gd` follow the existing pattern: load the scene → modify via Godot's own APIs → `PackedScene.pack` → `ResourceSaver.save`. The two project-level ops (`add_input_action`, `set_project_setting`) use `ProjectSettings.set_setting` + `ProjectSettings.save`.
- One generic `handleAuthoringOp` handler in `src/index.ts` (with a `needsScene` flag) validates the project/scene and dispatches through the existing `executeOperation`, plus an `inputSchema` per tool.
- No new dependencies; `build/` is gitignored (source-only change).

## Testing

- `godot --headless --check-only` parses clean.
- Each op verified end-to-end against a throwaway project (e.g. a `CharacterBody2D` with capsule collision, a keyframed `walk` animation, a limit-clamped `Camera2D`; `add_input_action` writes the `[input]` block; `set_project_setting` writes `main_scene` + window size).

Happy to adjust naming/structure to fit the project's conventions.
